### PR TITLE
Add the Operating Agreement

### DIFF
--- a/src/operating-agreement/index.html
+++ b/src/operating-agreement/index.html
@@ -368,101 +368,153 @@
     <section id="e-1-a-direct-client-service-projects">
       <h4>a. Direct Client Service Projects.</h4>
       <p id="e-1-a-i-description"> i. Description: These projects shall typically be paid by a third-party client in
-        exchange for services from the Cooperative and its agents. Direct Client Service Projects will typically have
-        a defined scope, timeline, and negotiated rates with the third-party client. Contracts for Direct Client
-        Service Projects shall typically be between the third-party client and the Cooperative. </p>
-      <p id="e-1-a-ii-consolidated-patronage-records"> ii. Consolidated Patronage Record: The Cooperative shall
-        maintain a consolidated record of all patronage by Members in support of all Direct Client Service Projects.
-      </p>
+        exchange for services from the Cooperative and its agents. Direct Client Service Projects will typically have a
+        defined scope, timeline, and negotiated rates with the third-party client. Contracts for Direct Client Service
+        Projects shall typically be between the third-party client and the Cooperative. </p>
+      <p id="e-1-a-ii-consolidated-patronage-records"> ii. Consolidated Patronage Record: The Cooperative shall maintain
+        a consolidated record of all patronage by Members in support of all Direct Client Service Projects. </p>
     </section>
     <section id="e-1-b-worker-owned-technology-projects">
       <h4>b. Worker-Owned Technology Projects.</h4>
       <p id="e-1-b-i-description">i. Description. Members of the Cooperative may choose to develop software programs,
-        applications, or other intellectual property for the purpose of commercialization, including but not limited
-        to use in future Direct Client Service Projects. The Cooperative anticipates that Worker-Owned Technology
-        Projects shall have a longer timeline for commercialization.</p>
+        applications, or other intellectual property for the purpose of commercialization, including but not limited to
+        use in future Direct Client Service Projects. The Cooperative anticipates that Worker-Owned Technology Projects
+        shall have a longer timeline for commercialization.</p>
       <p id="e-1-b-ii-distinct-and-separate-patronage-records"> ii. Distinct and Separate Patronage Records. The
         Cooperative seeks to simultaneously compensate those Members who contribute to the research and development of
         intellectual property while also maintaining flexibility for the Cooperative to determine the best means to
         commercialize any intellectual property. Therefore, for each Worker-Owned Technology Project, the Cooperative
-        shall maintain a record of each Member’s patronage for each Worker-Owned Technology Project separately. We
-        will keep written records of the date on which a product's development began and all Members and the
-        Cooperative will track their work hours on each product. If certain work cannot be adequately pegged to a
-        specific product, then the EAC, in consultation with the Members involved in the Worker-Owned Technology
-        Project, will make reasonable estimates of time allocations across products and document the basis for the
-        allocations.</p>
+        shall maintain a record of each Member’s patronage for each Worker-Owned Technology Project separately. We will
+        keep written records of the date on which a product's development began and all Members and the Cooperative will
+        track their work hours on each product. If certain work cannot be adequately pegged to a specific product, then
+        the EAC, in consultation with the Members involved in the Worker-Owned Technology Project, will make reasonable
+        estimates of time allocations across products and document the basis for the allocations.</p>
     </section>
   </section>
 </section>
+<section id="f-how-money-is-managed">
+  <h2> F. How Money is Managed in the Cooperative </h2>
+  <section id="f-1-capital-accounts">
+    <h3>1. Capital Accounts.</h3>
+    <p id="f-1-a-purpose-of-member-capital-accounts"> a. Each Member will have an internal account called the “Capital
+      Account,” which generally represents an accounting of the Member’s contributions to and distributions from the
+      Cooperative and the Member’s share of the Cooperative’s net profits and net losses. In particular, a Member’s
+      Capital Account includes the total of the Member’s Capital Contributions in cash and the fair market value of any
+      property contributed to the Cooperative (net of any liabilities that the Cooperative assumes) plus the Member’s
+      share of Cooperative net profits, minus the amount of cash or the fair market value of any property 8 (net of any
+      liabilities that the Member assumes) distributed to the Member from the Cooperative and minus the Member’s share
+      of the Cooperative’s net losses. </p>
+    <p id="f-1-b-separate-capital-accounts"> b. The Cooperative will maintain a separate Capital Account for each Member
+      in accordance with the capital account rules of Section 1.704-1(b)(2)(iv) of the Treasury Regulations, and this
+      Operating Agreement shall be interpreted and applied in a manner consistent with such Treasury Regulations. For
+      this purpose, the Cooperative may, upon the occurrence of the events specified in Treasury Regulations Section
+      1.704-1(b)(2)(iv)(f), increase or decrease the Capital Accounts in accordance with the rules of such regulation
+      and Treasury Regulations Section 1.704-1(b)(2)(iv)(g) to reflect a revaluation of Cooperative property. </p>
+    <p id="f-1-c-definitions-of-net-loss-and-profit"> c. For purposes of this Agreement, “net profit” or “net loss”
+      means the Cooperative’s taxable income or loss for federal income tax purposes for the applicable period, as
+      reasonably adjusted by the EAC in consultation with a qualified accountant or bookkeeper.</p>
+  </section>
+  <section id="f-2-taxes">
+    <h3>2. Taxes.</h3>
+    <p id="f-2-a-treatment-as-partnership">a. It is intended that the Cooperative be treated as a partnership for
+      federal, state, and local income tax purposes.</p>
+    <p id="f-2-b-member-responsibility-for-taxes">b. The Members shall, individually, be responsible for paying federal,
+      state, and any local income taxes attributable to their share of the Cooperative’s net profits and losses, whether
+      or not cash distributions are made by the Cooperative to the Members.</p>
+    <p id="f-2-c-mandatory-allocation-of-income">c. Members understand that all Cooperative income must be allocated to
+      the Members’ Capital Accounts, and acknowledge that they will need to pay taxes on the share of Cooperative income
+      that is allocated to their Capital Accounts, including income that has not been distributed to Members. In
+      addition, Members are responsible for paying all other taxes imposed on them individually, including quarterly
+      self-employment taxes, as applicable.</p>
+  </section>
+  <section id="f-3-fiscal-year">
+    <h3>3. Fiscal Year.</h3>
+    <p>The fiscal year of the Cooperative for accounting and tax purposes shall begin on January 1 and end on December
+      31, except for any shorter taxable years in the years of the Cooperative’s formation and termination.</p>
+  </section>
+  <section id="f-4-allocation-of-profits">
+    <h3>4. Allocation of Profits.</h3>
+    <p>The net profits of the Cooperative shall be allocated among the Members based on i) the type of Project; and ii)
+      the Member’s respective patronage for each project type, as follows:</p>
+    <section id="f-4-a-direct-client-service-projects">
+      <h4>a. Direct Client Service Projects</h4>
+      <p>Profits attributable to all Direct Client Service Projects shall be allocated to the Member’s based on the
+        consolidated patronage account maintained in connection with these projects under Section E.1.a.ii above.</p>
+    </section>
+    <section id="f-4-b-worker-owned-technology-projects">
+      <h4>b. Worker-Owned Technology Projects</h4>
+      <p>The Members agree and acknowledge that profits are not anticipated on Worker-Owned Technology projects until
+        the intellectual property can be successfully sold or licensed. When such profits are realized, they shall be
+        divided among all past and present worker-owners on the basis of the total number of hours each worker- owner
+        put into the product's development and marketing since the beginning of product development, consistent with the
+        patronage records maintained for each project under Section E.1.b.ii.</p>
+    </section>
+  </section>
+  <section id="f-5-retaining-earnings-and-making-distributions">
+    <h3>5. Retaining Earnings and Making Distributions.</h3>
+    <p>Distributions are cash or other assets paid to Members from their Capital Accounts. On a quarterly basis, 30% of
+      the Cooperative’s projected net profits attributable to the quarter in question, as reasonably determined by the
+      EAC in consultation with a qualified accountant or bookkeeper, shall be distributed to the Members in the same
+      manner that such net profits would be allocated to the Members pursuant to Section F.4. The Cooperative shall not
+      make distributions to the Members if doing so would leave the Cooperative unable to pay its obligations and
+      liabilities. A Member shall not be entitled to withdraw any part of the Member’s Capital Contribution or to
+      receive any distributions, whether of money or property, from the Cooperative except as specifically provided in
+      this Operating Agreement.</p>
+  </section>
+  <section id="f-6-sharing-losses">
+    <h3>6. Sharing Losses.</h3>
+    <p>If the Cooperative has net losses, Members will share those net losses in proportion to their Capital Accounts.
+    </p>
+  </section>
+  <section id="f-7-additional-tax-matters">
+    <h3>7. Additional Tax Matters.</h3>
+    <p>Except as otherwise provided in this Operating Agreement, all items of Cooperative income, gain, loss, deduction
+      and any other allocations not otherwise provided for shall be allocated among the Members in the same manner as
+      net profits and net losses under Section F.4 and Section F.6, as the case may be. To the extent a Member shall
+      have a negative Capital Account balance, there shall be a qualified income offset, as set forth in Section 1.704-
+      1(b)(2)(ii)(d) of the Treasury Regulations. Each item of income, gain, loss and deduction of the Cooperative for
+      federal, state and local income tax purposes will be allocated among the Members in the same manner as such
+      income, gain, loss or deduction is allocated among the Members’ Capital Accounts. Items of income, gain, loss and
+      deduction of the Cooperative with respect to any property contributed to the capital of the Cooperative shall be
+      allocated among the Members in accordance with Section 704(c) of the Internal Revenue Code of 1986, as amended
+      (the “Code”), using any method allowed by Section 704(c) of the Code and the Treasury Regulations thereunder
+      selected by the EAC. The Members shall make appropriate amendments to the allocations of items pursuant to this
+      Section if necessary in order to comply with Section 704 of the Code and applicable Treasury Regulations.</p>
+  </section>
+  <section id="f-8-tax-return-information">
+    <h3>8. Tax Return Information.</h3>
+    <p>Within 90 days after the end of each taxable year, the Cooperative shall send to each Member:</p>
+    <p id="f-8-a-member-tax-information"> a. the information necessary to complete federal and state income tax or
+      information returns; and </p>
+    <p id="f-8-b-copy-of-tax-returns">b. a copy of the Cooperative’s federal, state, and local income tax or information
+      returns for the year, if available, and if not as soon as it is available.</p>
+  </section>
+  <section id="f-9-tax-administration">
+    <h3>9. Tax Administration.</h3>
+    <p id="f-9-a-qualified-to-elect-out-of-partnership">a. The Members and the Cooperative acknowledge that the
+      Cooperative is currently qualified under Section 6221(b) of the Code to elect out of the centralized partnership
+      audit regime rules of Subchapter C of Chapter 63 of the Code, and hereby agree that the Cooperative shall make
+      such election for all applicable tax years, in accordance with Section 6221(b) of the Code and applicable Treasury
+      Regulations for so long as it qualifies.</p>
+    <p id="f-9-b-appointment-of-partnership-representative">b. In the event the Cooperative is required to appoint a
+      “Partnership Representative” within the meaning of Section 6223 of the Code (and any comparable provision of state
+      or local law, including as “tax matters partner”) with respect to a tax year of the Cooperative, the Chair or the
+      Treasurer of the EAC shall be the “Partnership Representative.”</p>
+    <section id="f-9-c-authorization-and-duties-of-partnership-representative">
+      <p>c. If applicable, the Partnership Representative:</p>
+      <p id="f-9-c-i-representation-of-cooperative-affairs-to-tax-authorities"> i. is authorized and required to
+        represent the Cooperative (at the Cooperative’s expense) in connection with all income tax examinations of the
+        Cooperative’s affairs by tax authorities; and </p>
+      <p id="f-9-c-ii-resolution-to-not-settle-or-resolve">ii. agrees not to settle or otherwise resolve any such
+        examination in a manner that would materially and adversely affect the Members without the prior written consent
+        of any such affected Members.</p>
+    </section>
+    <p id="f-9-d-member-agreement-to-cooperate-with-representative">d. If applicable, each Member agrees to cooperate
+      with the Partnership Representative and the Cooperative with respect to the conduct of such examinations.</p>
+  </section>
+</section>
 <pre>
-  F. How Money is Managed in the Cooperative 1. Capital Accounts. a. Each Member will have an internal
-  account called the “Capital Account,” which generally represents an accounting of the Member’s contributions to and
-  distributions from the Cooperative and the Member’s share of the Cooperative’s net profits and net losses. In
-  particular, a Member’s Capital Account includes the total of the Member’s Capital Contributions in cash and the fair
-  market value of any property contributed to the Cooperative (net of any liabilities that the Cooperative assumes) plus
-  the Member’s share of Cooperative net profits, minus the amount of cash or the fair market value of any property 8 (net
-  of any liabilities that the Member assumes) distributed to the Member from the Cooperative and minus the Member’s share
-  of the Cooperative’s net losses. b. The Cooperative will maintain a separate Capital Account for each Member in
-  accordance with the capital account rules of Section 1.704-1(b)(2)(iv) of the Treasury Regulations, and this Operating
-  Agreement shall be interpreted and applied in a manner consistent with such Treasury Regulations. For this purpose, the
-  Cooperative may, upon the occurrence of the events specified in Treasury Regulations Section 1.704-1(b)(2)(iv)(f),
-  increase or decrease the Capital Accounts in accordance with the rules of such regulation and Treasury Regulations
-  Section 1.704-1(b)(2)(iv)(g) to reflect a revaluation of Cooperative property. c. For purposes of this Agreement, “net
-  profit” or “net loss” means the Cooperative’s taxable income or loss for federal income tax purposes for the applicable
-  period, as reasonably adjusted by the EAC in consultation with a qualified accountant or bookkeeper. 2. Taxes. a. It is
-  intended that the Cooperative be treated as a partnership for federal, state, and local income tax purposes. b. The
-  Members shall, individually, be responsible for paying federal, state, and any local income taxes attributable to their
-  share of the Cooperative’s net profits and losses, whether or not cash distributions are made by the Cooperative to the
-  Members. c. Members understand that all Cooperative income must be allocated to the Members’ Capital Accounts, and
-  acknowledge that they will need to pay taxes on the share of Cooperative income that is allocated to their Capital
-  Accounts, including income that has not been distributed to Members. In addition, Members are responsible for paying all
-  other taxes imposed on them individually, including quarterly self-employment taxes, as applicable. 3. Fiscal Year. The
-  fiscal year of the Cooperative for accounting and tax purposes shall begin on January 1 and end on December 31, except
-  for any shorter taxable years in the years of the Cooperative’s formation and termination. 4. Allocation of Profits. The
-  net profits of the Cooperative shall be allocated among the Members based on i) the type of Project; and ii) the
-  Member’s respective patronage for each project type, as follows: a. Direct Client Service Projects: Profits attributable
-  to all Direct Client Service Projects shall be allocated to the Member’s based on the consolidated patronage account
-  maintained in connection with these projects under Section E.1.a.ii above. b. Worker-Owned Technology Projects: The
-  Members agree and acknowledge that profits are not anticipated on Worker-Owned Technology projects until the
-  intellectual property can be successfully sold or licensed. When such profits are realized, they shall be divided among
-  all past and present worker-owners on the basis of the total number of hours each worker- owner put into the product's
-  development and marketing since the beginning of product development, consistent with the patronage records maintained
-  for each project under Section E.1.b.ii. 5. Retaining Earnings and Making Distributions. Distributions are cash or other
-  assets paid to Members from their Capital Accounts. On a quarterly basis, 30% of the Cooperative’s projected net profits
-  attributable to the quarter in question, as reasonably determined by the EAC in consultation with a qualified accountant
-  or bookkeeper, shall be distributed to the Members in the same manner that such net profits would be allocated to the
-  Members pursuant to Section F.4. The Cooperative shall not make distributions to the Members if doing so would leave the
-  Cooperative unable to pay its obligations and liabilities. A Member shall not be entitled to withdraw any part of the
-  Member’s Capital Contribution or to receive any distributions, whether of money or property, from the Cooperative except
-  as specifically provided in this Operating Agreement. 9 6. Sharing Losses. If the Cooperative has net losses, Members
-  will share those net losses in proportion to their Capital Accounts. 7. Additional Tax Matters. Except as otherwise
-  provided in this Operating Agreement, all items of Cooperative income, gain, loss, deduction and any other allocations
-  not otherwise provided for shall be allocated among the Members in the same manner as net profits and net losses under
-  Section F.4 and Section F.6, as the case may be. To the extent a Member shall have a negative Capital Account balance,
-  there shall be a qualified income offset, as set forth in Section 1.704- 1(b)(2)(ii)(d) of the Treasury Regulations.
-  Each item of income, gain, loss and deduction of the Cooperative for federal, state and local income tax purposes will
-  be allocated among the Members in the same manner as such income, gain, loss or deduction is allocated among the
-  Members’ Capital Accounts. Items of income, gain, loss and deduction of the Cooperative with respect to any property
-  contributed to the capital of the Cooperative shall be allocated among the Members in accordance with Section 704(c) of
-  the Internal Revenue Code of 1986, as amended (the “Code”), using any method allowed by Section 704(c) of the Code and
-  the Treasury Regulations thereunder selected by the EAC. The Members shall make appropriate amendments to the
-  allocations of items pursuant to this Section if necessary in order to comply with Section 704 of the Code and
-  applicable Treasury Regulations. 8. Tax Return Information. Within 90 days after the end of each taxable year, the
-  Cooperative shall send to each Member: a. the information necessary to complete federal and state income tax or
-  information returns; and b. a copy of the Cooperative’s federal, state, and local income tax or information returns for
-  the year, if available, and if not as soon as it is available. 9. Tax Administration. a. The Members and the Cooperative
-  acknowledge that the Cooperative is currently qualified under Section 6221(b) of the Code to elect out of the
-  centralized partnership audit regime rules of Subchapter C of Chapter 63 of the Code, and hereby agree that the
-  Cooperative shall make such election for all applicable tax years, in accordance with Section 6221(b) of the Code and
-  applicable Treasury Regulations for so long as it qualifies. b. In the event the Cooperative is required to appoint a
-  “Partnership Representative” within the meaning of Section 6223 of the Code (and any comparable provision of state or
-  local law, including as “tax matters partner”) with respect to a tax year of the Cooperative, the Chair or the Treasurer
-  of the EAC shall be the “Partnership Representative.” c. If applicable, the Partnership Representative: i. is authorized
-  and required to represent the Cooperative (at the Cooperative’s expense) in connection with all income tax examinations
-  of the Cooperative’s affairs by tax authorities; and ii. agrees not to settle or otherwise resolve any such examination
-  in a manner that would materially and adversely affect the Members without the prior written consent of any such
-  affected Members. d. If applicable, each Member agrees to cooperate with the Partnership Representative and the
-  Cooperative with respect to the conduct of such examinations. G. Record Keeping and Accounting 1. Member Information
+  G. Record Keeping and Accounting 1. Member Information
   Statements: Each Member shall complete a Member Information Statement and provide it to the Administrator. It is the
   responsibility of the Member to provide a new 10 Statement to the Administrator any time the Member’s information
   changes. The Member Information Statement form is provided in Exhibit B. 2. Required Record Keeping: At all times, the

--- a/src/operating-agreement/index.html
+++ b/src/operating-agreement/index.html
@@ -1,26 +1,20 @@
 <header>
   <h1>Operating Agreement of Zinc Collective, LLC, a California Limited Liability Company</h1>
-
   <section class="preamble">
     <p>To produce software requires only imagination, thoughtful work, and the empathy to truly understand the needs of
       others.</p>
-
     <p>Zinc exists so all who contribute to the design, development, maintenance and distribution of software may derive
       permanent economic benefit from the software they create.</p>
-
     <p>Zinc seeks to create long term and immediate economic and ecological security for its members through the
-      practical
-      and equitable decentralization of power.</p>
-
+      practical and equitable decentralization of power.</p>
     <p>The Members (the “Members”) of Zinc Collective, LLC (the “Cooperative”) enter into this Operating Agreement,
       effective as of 1st October 2019, 2019 to provide for the governance and operations of the Cooperative and to
       specify the Members’ rights and obligations.</p>
   </section>
-
   <section id="recitals">
     <h2>Recitals</h2>
-    <p>WHEREAS, the Members of the Cooperative have chosen to operate as a worker cooperative because they believe
-      that worker cooperatives contribute to a more just society and to more just and healthy workplaces.</p>
+    <p>WHEREAS, the Members of the Cooperative have chosen to operate as a worker cooperative because they believe that
+      worker cooperatives contribute to a more just society and to more just and healthy workplaces.</p>
     <p>WHEREAS, the Members desire to enter into a written agreement pursuant to the California Act to establish their
       rights and responsibilities, to govern their relationships and to govern the affairs of the Cooperative and the
       conduct of its business, and hereby agree as follows:</p>
@@ -34,21 +28,18 @@
       California as the Members may hereafter determine. Its resident agent in the State of California shall be
       determined by the EAC.</p>
   </section>
-
   <section id="a-2-purpose">
     <h3>2. Purpose</h3>
     <p>The purpose of the Cooperative shall be, and such additional activities in furtherance of the foregoing as may be
-      unanimously approved in advance by the Members (collectively and
-      severally the “Approved Purpose”) and, without limiting the foregoing, to engage in any lawful activity for which
-      limited liability companies may be formed under the California Revised Uniform Limited Liability Company Act (the
-      “Act”).</p>
+      unanimously approved in advance by the Members (collectively and severally the “Approved Purpose”) and, without
+      limiting the foregoing, to engage in any lawful activity for which limited liability companies may be formed under
+      the California Revised Uniform Limited Liability Company Act (the “Act”).</p>
   </section>
-
   <section id="a-3-term-of-cooperative">
     <h3>3. Term of Cooperative</h3>
-    <p>The term of the Cooperative shall commence the date the Articles of Organization were
-      filed with the California Secretary of State and shall continue on a perpetual basis unless dissolved pursuant to
-      this Agreement or the Act.</p>
+    <p>The term of the Cooperative shall commence the date the Articles of Organization were filed with the California
+      Secretary of State and shall continue on a perpetual basis unless dissolved pursuant to this Agreement or the Act.
+    </p>
   </section>
 </section>
 <section id="b-membership">
@@ -57,7 +48,6 @@
     <h3>1. Classes of Members</h3>
     <p>The Cooperative shall have one class of Members.</p>
   </section>
-
   <section id="b-2-becoming-a-member">
     <h3>2. Becoming a Member</h3>
     <p>To become a Member of this Cooperative, a person seeking membership (a “Prospective Member”) must:</p>
@@ -66,25 +56,22 @@
       <p>A Prospective Member must work for the Cooperative for a minimum of 120 hours over a period of 12 consecutive
         months prior to becoming a Member.</p>
     </section>
-
     <section id="b-2-b-work-with-different-members">
       <h4>b. Work with Different Members</h4>
       <p>A Prospective Member must directly work with or collaborate with at least two (2) current members.</p>
     </section>
-
     <section id="b-2-c-take-part-in-leadership-training">
       <h4>c. Take Part in Leadership Training</h4>
       <p>Every Prospective Member must take part in leadership or entrepreneurial training and provide a certificate of
         her completion of such training to the Cooperative. Examples of acceptable trainings include trainings on
-        cooperative organizations, or programs that build the
-        leadership and entrepreneurial skills of the Prospective Member.</p>
+        cooperative organizations, or programs that build the leadership and entrepreneurial skills of the Prospective
+        Member.</p>
     </section>
     <section id="b-2-d-make-a-written-request-to-become-a-member">
       <h4>d. Make a Written Request to Become a Member</h4>
       <p>A Prospective Member must write a brief request to become a Member, explaining why they would like to become a
         Member.</p>
     </section>
-
     <section id="b-2-e-approval-by-the-eac-and-the-members">
       <h4>e. Approval by the EAC and the Members</h4>
       <p>A Prospective Member must be approved by the EAC (as defined below) and the Members, by means of the process
@@ -97,28 +84,24 @@
         than money, such as services or equipment, or by making payments over time, after she becomes a Member.</p>
     </section>
   </section>
-
   <section id="b-3-acceptance-of-members">
     <h3>3. Acceptance of Members</h3>
-    <p>The application review and approval process for a Prospective Member is
-      as follows:</p>
+    <p>The application review and approval process for a Prospective Member is as follows:</p>
     <p id="b-3-a-designation-of-member-advisor">a. Upon receipt of a Written Request by a Prospective Member to become a
-      Member, the EAC will designate a “Member
-      Advisor”, to advise the Prospective Member of the process of becoming a Member, to review the Prospective Member’s
-      Written Request, and verify that the Prospective Member has completed the requirements of Section C.2.a through
-      C.2.d, above. The Member Advisor must be a current Member but is not required to be a Manager or Officer.
-    </p>
+      Member, the EAC will designate a “Member Advisor”, to advise the Prospective Member of the process of becoming a
+      Member, to review the Prospective Member’s Written Request, and verify that the Prospective Member has completed
+      the requirements of Section C.2.a through C.2.d, above. The Member Advisor must be a current Member but is not
+      required to be a Manager or Officer. </p>
     <p id="b-3-b-confirmation-of-eligibility">b. Once the Member Advisor has confirmed that the Prospective Member has
       completed the requirements necessary to be eligible for membership, the Member Advisor will place the Prospective
       Member’s candidacy on the EAC’s agenda within thirty (30) days.</p>
-
     <p id="b-3-c-confirmation-of-eligibility">c. At a meeting of the EAC of the Cooperative, the EAC must unanimously
       vote to accept the Prospective Member as a new Member of the Cooperative. The vote shall be held without the
       Prospective Member in the room. Members of the EAC voting “No” shall be asked to explain themselves.</p>
     <section id="b-3-d-process-of-non-objection">
-      <p>d. Following approval by the EAC, the Members must approve the
-        admission of a Prospective Member through a process of non-objection. Specifically, the EAC shall send notice to
-        the Members that includes at minimum the following information:</p>
+      <p>d. Following approval by the EAC, the Members must approve the admission of a Prospective Member through a
+        process of non-objection. Specifically, the EAC shall send notice to the Members that includes at minimum the
+        following information:</p>
       <p id="b-3-d-i-name-of-member">i. name of the Prospective Member</p>
       <p id="b-3-d-ii-a-brief-description-of-their-work">ii. name of the Prospective Member</p>
       <p id="b-3-d-iii-name-of-collaborated-workers">iii. the names of the Members with whom the Prospective Member has
@@ -126,477 +109,395 @@
       <p id="b-3-d-iv-hours-and-months-worked">iv. the hours and months in which the Prospective Member has worked</p>
       <p id="b-3-d-v-name-of-membership-advisor">v. the name of the Membership Advisor.,</p>
     </section>
-
     <p id="b-3-e-objection-period-and-threshold">e. Following the notice described, current Members may raise an
-      objection within
-      seven (7) days. Unless twenty five percent (25%) or more of the existing Members object to the admission of the
-      Prospective Member in writing to the EAC within the stated deadline, for any reason or no reason, then Prospective
-      Member shall be admitted as a Member.</p>
-
+      objection within seven (7) days. Unless twenty five percent (25%) or more of the existing Members object to the
+      admission of the Prospective Member in writing to the EAC within the stated deadline, for any reason or no reason,
+      then Prospective Member shall be admitted as a Member.</p>
     <p id="b-3-f-return-of-capital-contribution">f. If the EAC declines to approve a Prospective Member or if twenty
-      five percent
-      (25%) or more of the existing Members object to the admission of the Prospective Member within the stated
-      deadline, then
-      the Prospective Member shall not be admitted as a Member, and the Cooperative shall return any of the Prospective
-      Member’s Initial Capital Contribution.</p>
+      five percent (25%) or more of the existing Members object to the admission of the Prospective Member within the
+      stated deadline, then the Prospective Member shall not be admitted as a Member, and the Cooperative shall return
+      any of the Prospective Member’s Initial Capital Contribution.</p>
     <p id="b-3-g-timing-of-membership">g. If the Prospective Member is approved by the EAC and the Members, and upon
       meeting all of the qualifications of Section A(2) above, the Prospective Member shall immediately become a Member.
     </p>
   </section>
-
   <section id="b-4-former-members">
     <h3>4. Former Members</h3>
     <p>If a former Member seeks to be reinstated as a Member, the EAC may by unanimous vote waive the candidacy period
       and application process and renew a former Member’s Membership.</p>
   </section>
-
   <section id="b-5-no-transfers-of-membership">
     <h3>5. No Transfers of Membership.</h3>
-    <p>No Member may transfer her Membership or any right
-      arising from that Membership. Any attempted assignment or transfer of Membership shall be void and will not confer
-      rights on the intended assignee or transferee.</p>
+    <p>No Member may transfer her Membership or any right arising from that Membership. Any attempted assignment or
+      transfer of Membership shall be void and will not confer rights on the intended assignee or transferee.</p>
   </section>
 </section>
-
 <section id="c-member-rights-and-duties">
   <h2>C. Member Rights and Duties</h2>
   <section id="c-1-duty-to-devote-time">
     <h3>1. Duty to Devote Time:</h3>
-    <p>Subject to the participation minimums contained in Section H.2.b, each Member shall devote
-      such time and attention to the Cooperative as he or she chooses. There shall be no requirement that Members
-      contribute an equal amount of time to the Cooperative.</p>
+    <p>Subject to the participation minimums contained in Section H.2.b, each Member shall devote such time and
+      attention to the Cooperative as he or she chooses. There shall be no requirement that Members contribute an equal
+      amount of time to the Cooperative.</p>
   </section>
-
   <section id="c-2-right-to-work">
     <h3>2. Right to Work:</h3>
-    <p>Members acknowledge that work opportunities may fluctuate
-      with the Cooperative’s business needs, and that the practical needs of the business may mandate that certain Members
-      work more than others. However, Members agree to strive to offer all Members the opportunity to work and earn money in
-      the Cooperative.</p>
+    <p>Members acknowledge that work opportunities may fluctuate with the Cooperative’s business needs, and that the
+      practical needs of the business may mandate that certain Members work more than others. However, Members agree to
+      strive to offer all Members the opportunity to work and earn money in the Cooperative.</p>
+  </section>
+  <section id="c-3-duty-to-attend-meetings">
+    <h3>3. Duty to Attend Meetings</h3>
+    <p>Members shall strive to attend each Monthly Member Meeting.</p>
+  </section>
+  <section id="c-4-duty-of-confidentiality">
+    <h3>4. Duty of Confidentiality</h3>
+    <p>Due to the nature of its business, confidentiality is important to the Cooperative, the Members, and Cooperative
+      clients. From time to time, Members may learn information about the Cooperative, its clients, its client projects,
+      and research and development projects of the Cooperative that is sensitive or proprietary information
+      (collectively, “Confidential Information”). Confidential Information shall not include information that, at the
+      time of disclosure:</p>
+    <p id="c-4-a-generally-available"> a. is or becomes generally available to and known by the public other than as a
+      result of, directly or indirectly, any breach of this Section by the Members; </p>
+    <p id="c-4-b-available-from-non-confidential-source"> b. is or becomes available to a Member on a non-confidential
+      basis from a third-party source, provided that such third party is not and was not prohibited from disclosing such
+      Confidential Information; </p>
+    <p id="c-b-c-known-prior-to-disclosure"> c. was known by or in the possession of the Member before being disclosed
+      or learned through the Cooperative; or </p>
+    <p id="c-b-d-disclosure-required-by-law"> d. is required to be disclosed under applicable federal, state or local
+      law, regulation or a valid order issued by a court or governmental agency of competent jurisdiction. </p>
+    <p> In furtherance of the foregoing, each Member shall: (A) protect and safeguard the confidentiality of all
+      Confidential Information with at least the same degree of care as she would protect her own Confidential
+      Information, but in no event with less than a commercially reasonable degree of care; (B) not use any Confidential
+      Information, or permit it to be accessed or used, for any purpose other than to exercise her rights or perform its
+      obligations under this Agreement; and (C) not disclose any such Confidential Information to any person or entity,
+      except to other Members or Cooperative representatives who need to know the Confidential Information to assist the
+      Member, or act on its behalf, to exercise its rights or perform its obligations under the Agreement. A Member
+      shall be responsible for any breach of this Section caused by that Member or her representatives. Members shall
+      promptly return or destroy all copies of Confidential Information upon termination of her membership. In addition
+      to all other remedies available at law, the Cooperative may seek equitable relief (including injunctive relief)
+      against a Member or her representatives to prevent the breach or threatened breach of this Section and to secure
+      its enforcement. </p>
   </section>
 </section>
-
-3. Duty to Attend Meetings: Members shall strive to attend each Monthly Member Meeting. 4. Duty of
-Confidentiality: Due to the nature of its business, confidentiality is important to the Cooperative, the Members, and
-Cooperative clients. From time to time, Members may learn information about the Cooperative, its clients, its client
-projects, and research and development projects of the Cooperative that is sensitive or proprietary information
-(collectively, “Confidential Information”). Confidential Information shall not include information that, at the time
-of
-disclosure:
-a. is or becomes generally available to and known by the public other than as a result of,
-directly or indirectly, any breach of this Section by the Members; b. is or becomes available to a Member on a
-non-confidential basis from a third-party source,
-provided that such third party is not and was not prohibited from disclosing such Confidential Information; c. was
-known
-by or in the possession of the Member before being disclosed or learned through
-the Cooperative; or d. is required to be disclosed under applicable federal, state or local law, regulation or a valid
-order issued by a court or governmental agency of competent jurisdiction. In furtherance of the foregoing, each Member
-shall: (A) protect and safeguard the confidentiality of all Confidential Information with at least the same degree of
-care as she would protect her own Confidential Information, but in no event with less than a commercially reasonable
-degree of care; (B) not use any Confidential Information, or permit it to be accessed or used, for any purpose other
-than to exercise her rights or perform its obligations under this Agreement; and (C) not disclose any such
-Confidential
-Information to any person or entity, except to other Members or Cooperative representatives who need to know the
-Confidential Information to assist the Member, or act on its behalf, to exercise its rights or perform its obligations
-under the Agreement. A Member shall be responsible for any breach of this Section caused by that Member or her
-representatives. Members shall promptly return or destroy all copies of Confidential Information upon termination of
-her
-4
-membership. In addition to all other remedies available at law, the Cooperative may seek equitable relief (including
-injunctive relief) against a Member or her representatives to prevent the breach or threatened breach of this Section
-and to secure its enforcement. D. How to Govern and Manage the Cooperative
-1. All Members of the Cooperative shall be Managers: All Members shall be Managers of the Cooperative. It is the
-intent
-of the Members to actively engage in, lead initiatives for, and manage the business of the Cooperative. As all Members
-are Managers, it is the intent of the Cooperative that no Member is considered an employee of the Cooperative as a
-result of being a Member. 2. The Executive Administration Committee (“EAC”).
-a. General: In order to assist the Members in the administration of the Cooperative, the Members shall appoint an
-Executive Administration Committee (the “EAC”) to provide administrative services. Except as otherwise provided by the
-RULLCA, the EAC shall exercise such powers and perform such duties as specified in this Agreement and as determined by
-the Members. b. Eligibility; Appointment; Term: Any person serving on the EAC must be a current Member of the
-Cooperative. The Members may set additional qualification and eligibility requirements for participation in the EAC.
-The
-EAC shall have the number of seats, titles, and terms as are determined by the Members. The method for electing or
-appointing members to the EAC shall be determined by the Members. c. Signing Authority: Subject to the terms of this
-Agreement, for the purposes of clarity and administration, the signature of any two members of the EAC acting in
-compliance with the provisions of this Agreement shall bind the Cooperative. 3. Member Management Meetings: The
-Members
-shall meet regularly for Management Meetings. Members may participate by telephone, skype, or another similar
-mechanism.
-Management Meetings shall be monthly, and shall cover, among other topics, a report about normal business operations
-from the previous Month, a report on finances, and planning upcoming events. No less than each quarter, the Treasurer
-shall give a budget report which shall include an accounting of the Cooperative’s expenses, revenues, and an update on
-the Member’s Capital Accounts, if applicable. 4. Voting:
-a. Each Member shall have one vote on each matter submitted for a vote. b. Cumulative voting (i.e., pooling of votes)
-shall not be permitted for any purpose. c. Proxy voting shall not be permitted for any purpose. d. Unless otherwise
-specified, all votes shall be conducted using the processes in Section F.3. e. Ballots. Written ballots (including
-written ballots administered online) or personal voting may be used at any meeting of Members. Personal voting may
-include, among other things, raising a hand or vocalizing a vote. If the ballot is not written, a member of the EAC
-must
-record each vote and incorporate each vote into the meeting minutes. Any written ballot used at a meeting shall:
-i. Describe the proposal; ii. Provide an opportunity to approve or disapprove the proposed action; and iii. State that
-unless revoked by the Member voting in person at the meeting, the ballot will be counted if received by the
-Cooperative
-on or before the time of the meeting. f. When ballots are distributed at a meeting, the number of Members voting shall
-be considered present for the purposes of determining quorum with respect to the specific actions in the ballot.
-5
-5. Member Unable to Attend Meeting: If a Member is unable to attend a meeting, then that Member must notify the other
-Members twenty-four (24) hours prior to the commencement of the meeting. If the Member is unable to participate in the
-meeting in any form, then that Member shall be responsible for reading the minutes and notes taken from that meeting.
-Each Member shall make a good faith effort to attend each meeting.
-a. Notice: Notice of a meeting shall be given to each Member by electronic transmission, or by mail or other means of
-written communication. Notice to Members must be given no less than five (5) days before the date of the meeting. The
-Cooperative shall also publicly display a calendar, whether physically or electronically, which lists the date of the
-next meeting. The notice shall state the following:
-i. Meeting place, date, and time of the meeting; ii. If applicable, the log-in or call-in information for
-telephone/video/web conference;
-and iii. In the case of a special meeting, the general nature of the business to be
-transacted, and that no other business may be transacted. b. Member access of records: The Cooperative shall ensure
-that
-all documents related to the meetings, including minutes, notes, proposals, adopted policies and procedures, and
-ballots, shall remain publicly available for the Cooperative and its Members. 6. Emergency Special Meetings:
-a. An emergency meeting can only be called for a single decision item (not discussion item)
-that absolutely cannot wait until the next scheduled meeting. b. Emergency meetings may be called by any two Members
-by
-giving notice to the EAC. The
-EAC must schedule the emergency meeting within 72 hours of receiving notice. c. Notice of the emergency meeting will
-be
-given by email or by individual text message or
-phone call to all Members. d. The Notice of the emergency meeting shall include the decision item. e. Vote to Delay:
-The
-EAC may include with the Notice a binding vote with the Notice on whether the question of whether the item can or
-cannot
-wait until the next scheduled meeting time.
-i. If, at one hour before the emergency meeting, a majority of responses in the digital
-vote agrees that the meeting can wait, no meeting will take place. ii. If an emergency meeting does not take place,
-this
-item will be added to the next
-general meeting agenda. f. The agenda for an emergency meeting will be the emergency item only. g. An emergency
-meeting
-can take place at the regular meeting place of the Cooperative or by
-conference call. 7. Proposals: All Members shall be invited and welcomed to bring Proposals to the Cooperative. A
-Proposal includes, but is not limited to, any request to change Cooperative policy, procedures, or processes, to
-engage
-in a new project, or to change the roles and positions of Members. The EAC, in consultation with Members, will
-establish
-procedures for Members to bring a proposal to a vote. 8. Adopting Time Sensitive Proposals Outside of Meetings: In the
-event that an opportunity or need arises, and 60% of the Members agree that a Proposal needs to be considered quickly,
-then, if the Members are not in a meeting, the Members shall vote on a Proposal and the Proposal shall pass with the
-approval of 80% of the Members. The EAC shall keep a record of the proposal and outcome of the vote. If fewer than 60%
-of the Members agree that a decision is needed quickly, then the Proposal shall be made at the next Member Meeting and
-shall be brought and considered in the manner in which Proposals are required to be brought.
-6
-9. Quorum. The minimum number of Members needed to be at a meeting to make decisions binding is referred to as
-“quorum.”
-The Cooperative intends for its Members to initiate and lead projects for the Cooperative. It has therefore adopted a
-decision-making structure where most decisions can be made at a meeting with a smaller quorum while major decisions
-require a higher quorum.
-a. Default Provisions: Unless designated a Major Decision (as defined below), all proposals of the Cooperative may be
-considered and decided at a meeting with quorum of fifty percent (50%) of the Membership in attendance. b. Major
-decisions: The following proposals require a quorum of at least seventy percent
-(70%) of the Members in attendance:
-i. Getting a loan in amount of $50,000 or greater; ii. Changing the Cooperative’s primary business; iii. Merging,
-selling, or dissolving the Cooperative; iv. Amending this Agreement; and
-v. Entering the Cooperative into a financial obligation that exceeds $1,000. 10. Approving Proposals. Unless otherwise
-specified in this Agreement (including Section F.9 below) or as required by law, all proposals shall be approved by
-two-thirds (2/3rds) of the Members at a meeting with quorum.
-For illustration purposes only, here are some examples of quorum and approval requirements:
-Default Decision Major Decision
-Total Members 13 13
-
-Quorum required to hold a meeting 7
-(50% of 13, rounded up)
-11. Unanimous Consent Required:
-10 (70% of 13, rounded up)
-
-a. Amend this Operating Agreement. The unanimous consent of the Members is required to
-amend this Operating Agreement. b. Acts outside of the Ordinary Course of the Cooperative’s Activities. Pursuant to
-Section 17704.07(c)(4) of RULLCA (the California law governing LLCs), the unanimous approval of the Members is
-required
-to take any activities outside the ordinary course of the Cooperative’s activities, except as otherwise provided under
-Article 10 of RULLCA.
-
-Number of Votes to approve a proposal with a minimum Quorum in attendance*
-5 (2/3rds of 7)
-7 (2/3rds of 10, rounded up)
-7 (2/3rds of 10, rounded up)
-Number of Votes to approve a proposal with 11 Members in attendance*
-8 (2/3rds of 11)
-8 (2/3rds of 11)
-8 (2/3rds of 11)
-
-*Note: Quorum is calculated based on the total number of all Members. If greater than the minimum quorum actually
-attend
-a meeting, the votes required for approval are based on the actual number of Members in attendance, not the quorum
-number.
-7
-12. Committees and Delegation: The Members may delegate the management of certain tasks and realms to committees, and
-those committees shall meet separately from the Management Meetings. 13. Adopting Other Rules and Policies: The
-Members
-may adopt other rules and policies outside of this Agreement. The Members shall record all other rules and policies in
-a
-separate document that is provided to all Members, or they shall amend this Agreement to include the new rules and
-policies. E. Cooperative Projects
-1. Two Types of Cooperative Projects: The Cooperative will engage in two distinct types of projects
-and will record patronage for separately for each type, as follows:
-a. Direct Client Service Projects.
-i. Description: These projects shall typically be paid by a third-party client in
-exchange for services from the Cooperative and its agents. Direct Client Service Projects will typically have a
-defined
-scope, timeline, and negotiated rates with the third-party client. Contracts for Direct Client Service Projects shall
-typically be between the third-party client and the Cooperative. ii. Consolidated Patronage Record: The Cooperative
-shall maintain a consolidated record of all patronage by Members in support of all Direct Client Service Projects. b.
-Worker-Owned Technology Projects.
-i. Description. Members of the Cooperative may choose to develop software
-programs, applications, or other intellectual property for the purpose of commercialization, including but not limited
-to use in future Direct Client Service Projects. The Cooperative anticipates that Worker-Owned Technology Projects
-shall
-have a longer timeline for commercialization. ii. Distinct and Separate Patronage Records. The Cooperative seeks to
-simultaneously compensate those Members who contribute to the research and development of intellectual property while
-also maintaining flexibility for the Cooperative to determine the best means to commercialize any intellectual
-property.
-Therefore, for each Worker-Owned Technology Project, the Cooperative shall maintain a record of each Member’s
-patronage
-for each Worker-Owned Technology Project separately. We will keep written records of the date on which a product's
-development began and all Members and the Cooperative will track their work hours on each product. If certain work
-cannot be adequately pegged to a specific product, then the EAC, in consultation with the Members involved in the
-Worker-Owned Technology Project, will make reasonable estimates of time allocations across products and document the
-basis for the allocations. F. How Money is Managed in the Cooperative
-1. Capital Accounts.
-a. Each Member will have an internal account called the “Capital Account,” which generally represents an accounting of
-the Member’s contributions to and distributions from the Cooperative and the Member’s share of the Cooperative’s net
-profits and net losses. In particular, a Member’s Capital Account includes the total of the Member’s Capital
-Contributions in cash and the fair market value of any property contributed to the Cooperative (net of any liabilities
-that the Cooperative assumes) plus the Member’s share of Cooperative net profits, minus the amount of cash or the fair
-market value of any property
-8
-(net of any liabilities that the Member assumes) distributed to the Member from the Cooperative and minus the Member’s
-share of the Cooperative’s net losses. b. The Cooperative will maintain a separate Capital Account for each Member in
-accordance with the capital account rules of Section 1.704-1(b)(2)(iv) of the Treasury Regulations, and this Operating
-Agreement shall be interpreted and applied in a manner consistent with such Treasury Regulations. For this purpose,
-the
-Cooperative may, upon the occurrence of the events specified in Treasury Regulations Section 1.704-1(b)(2)(iv)(f),
-increase or decrease the Capital Accounts in accordance with the rules of such regulation and Treasury Regulations
-Section 1.704-1(b)(2)(iv)(g) to reflect a revaluation of Cooperative property. c. For purposes of this Agreement, “net
-profit” or “net loss” means the Cooperative’s taxable
-income or loss for federal income tax purposes for the applicable period, as reasonably adjusted by the EAC in
-consultation with a qualified accountant or bookkeeper. 2. Taxes.
-a. It is intended that the Cooperative be treated as a partnership for federal, state, and local
-income tax purposes. b. The Members shall, individually, be responsible for paying federal, state, and any local
-income taxes attributable to their share of the Cooperative’s net profits and losses, whether or not cash
-distributions
-are made by the Cooperative to the Members. c. Members understand that all Cooperative income must be allocated to the
-Members’ Capital
-Accounts, and acknowledge that they will need to pay taxes on the share of Cooperative income that is allocated to
-their
-Capital Accounts, including income that has not been distributed to Members. In addition, Members are responsible for
-paying all other taxes imposed on them individually, including quarterly self-employment taxes, as applicable. 3.
-Fiscal
-Year. The fiscal year of the Cooperative for accounting and tax purposes shall begin on
-January 1 and end on December 31, except for any shorter taxable years in the years of the Cooperative’s formation and
-termination. 4. Allocation of Profits. The net profits of the Cooperative shall be allocated among the Members
-based on i) the type of Project; and ii) the Member’s respective patronage for each project type, as follows:
-a. Direct Client Service Projects: Profits attributable to all Direct Client Service Projects shall be
-allocated to the Member’s based on the consolidated patronage account maintained in connection with these projects
-under
-Section E.1.a.ii above. b. Worker-Owned Technology Projects: The Members agree and acknowledge that profits are not
-anticipated on Worker-Owned Technology projects until the intellectual property can be successfully sold or licensed.
-When such profits are realized, they shall be divided among all past and present worker-owners on the basis of the
-total
-number of hours each worker- owner put into the product's development and marketing since the beginning of product
-development, consistent with the patronage records maintained for each project under Section E.1.b.ii. 5. Retaining
-Earnings and Making Distributions. Distributions are cash or other assets paid to
-Members from their Capital Accounts. On a quarterly basis, 30% of the Cooperative’s projected net profits attributable
-to the quarter in question, as reasonably determined by the EAC in consultation with a qualified accountant or
-bookkeeper, shall be distributed to the Members in the same manner that such net profits would be allocated to the
-Members pursuant to Section F.4. The Cooperative shall not make distributions to the Members if doing so would leave
-the
-Cooperative unable to pay its obligations and liabilities. A Member shall not be entitled to withdraw any part of the
-Member’s Capital Contribution or to receive any distributions, whether of money or property, from the Cooperative
-except
-as specifically provided in this Operating Agreement.
-9
-6. Sharing Losses. If the Cooperative has net losses, Members will share those net losses in proportion
-to their Capital Accounts. 7. Additional Tax Matters. Except as otherwise provided in this Operating Agreement, all
-items of Cooperative income, gain, loss, deduction and any other allocations not otherwise provided for shall be
-allocated among the Members in the same manner as net profits and net losses under Section F.4 and Section F.6, as the
-case may be. To the extent a Member shall have a negative Capital Account balance, there shall be a qualified income
-offset, as set forth in Section 1.704- 1(b)(2)(ii)(d) of the Treasury Regulations. Each item of income, gain, loss and
-deduction of the Cooperative for federal, state and local income tax purposes will be allocated among the Members in
-the
-same manner as such income, gain, loss or deduction is allocated among the Members’ Capital Accounts. Items of income,
-gain, loss and deduction of the Cooperative with respect to any property contributed to the capital of the Cooperative
-shall be allocated among the Members in accordance with Section 704(c) of the Internal Revenue Code of 1986, as
-amended
-(the “Code”), using any method allowed by Section 704(c) of the Code and the Treasury Regulations thereunder selected
-by
-the EAC. The Members shall make appropriate amendments to the allocations of items pursuant to this Section if
-necessary
-in order to comply with Section 704 of the Code and applicable Treasury Regulations. 8. Tax Return Information. Within
-90 days after the end of each taxable year, the Cooperative shall
-send to each Member:
-a. the information necessary to complete federal and state income tax or information returns;
-and b. a copy of the Cooperative’s federal, state, and local income tax or information returns for the
-year, if available, and if not as soon as it is available. 9. Tax Administration.
-a. The Members and the Cooperative acknowledge that the Cooperative is currently qualified
-under Section 6221(b) of the Code to elect out of the centralized partnership audit regime rules of Subchapter C of
-Chapter 63 of the Code, and hereby agree that the Cooperative shall make such election for all applicable tax years,
-in
-accordance with Section 6221(b) of the Code and applicable Treasury Regulations for so long as it qualifies. b. In the
-event the Cooperative is required to appoint a “Partnership Representative” within the
-meaning of Section 6223 of the Code (and any comparable provision of state or local law, including as “tax matters
-partner”) with respect to a tax year of the Cooperative, the Chair or the Treasurer of the EAC shall be the
-“Partnership
-Representative.” c. If applicable, the Partnership Representative:
-i. is authorized and required to represent the Cooperative (at the Cooperative’s expense) in connection with all
-income
-tax examinations of the Cooperative’s affairs by tax authorities; and ii. agrees not to settle or otherwise resolve
-any
-such examination in a manner
-that would materially and adversely affect the Members without the prior written consent of any such affected Members.
-d. If applicable, each Member agrees to cooperate with the Partnership Representative and the
-Cooperative with respect to the conduct of such examinations.
-G. Record Keeping and Accounting
-1. Member Information Statements: Each Member shall complete a Member Information Statement and provide it to the
-Administrator. It is the responsibility of the Member to provide a new
-10
-Statement to the Administrator any time the Member’s information changes. The Member Information Statement form is
-provided in Exhibit B. 2. Required Record Keeping: At all times, the Cooperative must maintain records of the
-following:
-a. Organizing and Governing Documents: An updated copy of the Cooperative’s current Operating Agreement, Articles of
-Organization, and any rules or policies adopted by the Member outside of this Agreement. b. Financial Information:
-Information regarding the financial condition of the Cooperative:
-i. Profit and loss statements, prepared on a quarterly basis; ii. Balance sheets, prepared on a quarterly basis; iii.
-Descriptions of the cash, bank account balances, and property of the Cooperative; iv. Patronage Records consistent
-with
-Sections E.1.a.ii and E.1.b.ii; and
-v. Any contributions that Members have been agreed to make in the future. c. Tax Returns: A copy of the federal,
-state,
-and local income taxes for each year, updated
-once available. d. Current Member Information Statements: Copies of all updated Member Information
-Statements. e. Past Member List: A list of all past Cooperative Members, including names, last known mailing address,
-phone number, email address, the Member’s designated beneficiary for payment of the Member’s Capital Account upon
-death
-and for dissolution distributions, dates of membership, and total number of hours worked during the membership. f.
-Meeting Records: A record of the minutes of Management Meeting proceedings. 3. Member Rights to Inspect Records: Each
-Member has the right to demand and receive, within a reasonable period of time, a copy of any of the above documents
-for
-any purpose reasonably related to their interest as a Member of the Cooperative. If a member would like a copy to
-keep,
-that Member shall pay for the copying expenses. The inspection may be made in person by the Member, or by an agent or
-attorney for the Member. 4. Annual Report: The Treasurer shall prepare, and all Members must receive, a copy of the
-annual report, prepared no later than 120 days after the end of the Cooperative’s fiscal year. The annual report must
-contain:
-a. A balance sheet; b. A detailed profit and loss statement for the full fiscal year; c. A statement of all debts of
-the
-Cooperative; d. A description of the basis on which each Member’s share of patronage or Loss was
-determined. H. How to Terminate Membership in The Cooperative
-1. Voluntary Resignation. A Member may withdraw from the Cooperative at any time upon written
-notice to the EAC. 2. Involuntary Termination: A Member is subject to withdrawal or expulsion from the Cooperative
-under the following circumstances:
-a. Death b. Performing no services for either a Direct Client Services Project or a Worker-Owned Technology Project
-for
-six (6) consecutive months unless that Member gives notice to the
-11
-EAC of an illness or disability that may prevent the Member from performing such services for no more than nine (9)
-months or under such other circumstances as are approved by the EAC; or c. Failure to achieve a Vote of Confidence. 3.
-Vote of Confidence: A Member may be expelled from the Cooperative based on a “Vote of Confidence” with respect to any
-Member’s status as a Member in the Cooperative if the Vote of Confidence is not approved.
-a. Violations that may trigger a Vote of Confidence include
-i. committing physical or verbal acts of violence against a Member or other persons
-related to the Cooperative; ii. using Cooperative resources or funds for personal benefit without the Members’
-approval; iii. Conviction of any felony; iv. Violating the terms of a client agreement, this Agreement, or the
-Cooperative’s
-Code of Conduct. b. A Vote of Confidence on a Member who committed a violation (the “Violating Member”) requires the
-affirmative vote of 80% of the membership for approval, not including the Violating Member. c. Where a Vote of
-Confidence regarding a Violating Member has failed, the membership of
-such Member shall be terminated. d. Upon notice of a violation that would trigger a Vote of Confidence, the EAC shall
-give notice to the Members of the reason(s) for the Vote of Confidence and no less than fourteen (14) days for the
-Members to submit their votes. Where a Member declines to submit a vote in response to such notice, it shall be
-considered a vote of no confidence. e. Specifically, the EAC shall send notice to the Members that includes at minimum
-the
-following information:
-i. name of the Member subject to a Vote of Confidence ii. a brief description of the triggering event prepared by the
-EAC; iii. A statement from the Member, if desired, disputing the triggering event iv. At the EAC’s option, a response
-from the EAC to the Member’s dispute of the
-triggering event. 4. Rights upon Termination.
-a. No Further Activities. Termination of membership automatically removes an individual from all positions in the
-Cooperative, including but not limited to any committee of the Cooperative. b. No Waiver of Liabilities. A Member
-whose
-membership in the Cooperative is terminated
-shall be liable for any charges, dues, or other obligations incurred before the termination. c. Conversion of
-Membership
-to Loan. When a Member ends her membership voluntarily or involuntarily (except in the case of death, see below), that
-Member’s Capital Account and other debts the Cooperative owes the Member become a loan to the Cooperative. That loan
-must be paid to the Member within five years. The loan shall not accumulate interest during the first year. After the
-first year, it will accumulate interest at an APR of 3% on the outstanding amount. If funds are available and, with
-approval by at least 75% of the Members, the Cooperative may elect to pay the Member within 30 days of when she
-leaves.
-There shall be no fee or penalty for prepayment of such loan by the Cooperative. d. Designated Beneficiary in case of
-Death. If a Member passes away, the payment will go to the Member’s Designated Beneficiary(ies), whose name appears in
-the Statement of Information of that Member. If a Member has passed away and has not named a
-12
-Designated Beneficiary, or if the Cooperative cannot find the ex‐Member or Designated Beneficiary after reasonable
-effort, the Cooperative will not be obliged to distribute to that Member, her Designated Beneficiary, or any other
-heir
-or beneficiary of that Member. I. How to Resolve Conflicts
-1. When a conflict arises between Members or between a Member and the Cooperative that cannot be resolved through good
-faith discussion, either party may elect to submit to binding arbitration. The venue for arbitration shall be agreed
-to
-by the parties to the arbitration, or if the parties cannot agree, at a venue selected by the EAC. 2. All arbitration
-decisions shall be final, binding and conclusive on all the parties to arbitration, and legal judgment may be entered
-based upon such decision in accordance with applicable law in any court having jurisdiction to do so. 3. The opposing
-parties shall agree to each pay half the cost of binding arbitration procedures. J. Additional Provisions
-1. Complete Agreement: This Agreement and the Articles of Organization constitute the complete and exclusive statement
-of the Members with respect to the subject matter herein and therein and replace and supersede all prior written and
-oral agreements or statements by the Members. If there is any conflict between the provisions of this Agreement and
-the
-Articles of Organization, then the provisions of this Agreement, to the extent permitted under California law, shall
-control. 2. Mandatory Review of Operating Agreement: Upon the occurrence of any of the following events, the
-Cooperative
-will appoint a committee to review and recommend to the Cooperative amendments to this Agreement. The committee must
-deliver its recommendations at a Monthly Member Meeting no less than six (6) months after the occurrence of the
-triggering event.
-a. A change in the Approved Purpose of the Cooperative. b. When the total number of Members reaches twelve (12). c.
-When
-total revenues from Worker-Owned Technology Projects exceeds $100,000. 3. If a Member is Sued by Someone Outside of
-the
-Cooperative: All Members will be indemnified and held harmless by the Cooperative from and against any and all claims
-of
-any nature arising out of a Member's participation in Cooperative affairs. A Member will not be entitled to
-indemnification under this section for liability arising out of gross negligence or willful misconduct of the Member
-or
-the breach by the Member of any provisions of this Agreement. This means, for example, that the Cooperative will
-compensate and help to defend a Member who is sued for damages that occur when the Member is working for the
-Cooperative. 4. Members Will Not Be Liable for Good Faith Mistakes: If a Member is acting in good faith and in service
-of the Cooperative, and if she makes a mistake or error in judgment, or commits an unintentional act or omission, the
-Member will not be liable to the Cooperative or to any other Member for the mistake or error. The Member will be
-liable
-only for acts and omissions involving intentional wrongdoing. 5. Gender Pronouns: Even though we typically use “she”
-and
-“her” throughout this Agreement, these
-words should be interpreted to mean “he, she, or they” or “his, her, or their.”
-13
-6. The Bold Headings Are Not a Legally Binding Part of This Agreement: We have included very descriptive headings in
-this Agreement, in order to make it easy to read and navigate. However, these bold headings shall not be considered to
-be a legally binding part of this Agreement. 7. How to Provide Notice to Members: Any time that a Member or the
-Cooperative is required to give notice to the Members, the notice shall be given by any of the following methods: 1)
-Notice may be mailed to the physical addresses of the Members, in which case notice shall be considered given three
-business days after place the notice in the mail with first class postage; 2) Notice may be delivered by email or text
-to the email addresses and phone numbers provided by Members, in which case notice shall be considered delivered when
-the member replies to the email and acknowledges receipt; 3) Notice may be delivered in person, in which case notice
-shall be considered delivered when the notice is placed in the hands of the Member, and 4) Notice may be delivered by
-telephone, in which case notice shall be considered delivered when the receiving Member voices acknowledgment of the
-notice. 8. Severability: If any provision of this Agreement is held by a court to be invalid or unenforceable, Members
-agree that the provision shall be reduced in scope by the court only to the extent deemed necessary by that court to
-render the provision reasonable and enforceable, and the remaining provisions of this Agreement will not be affected
-or
-invalidated as a result. 9. This Agreement is Binding on Successors: This Agreement and the terms and conditions
-contained in this Agreement apply to and are binding upon the Member's successors, assigns, executors, administrators,
-beneficiaries, and representatives.
-14
-the Members hereby agree to all of the terms and conditions in this Agreement.
-
+<section id="d-how-to-govern-and-manage">
+  <h2>D. How to Govern and Manage the Cooperative</h2>
+  <section id="d-1-all-members-are-managers">
+    <h3>1. All Members of the Cooperative shall be Managers</h3>
+    <p>All Members shall be Managers of the Cooperative. It is the intent of the Members to actively engage in, lead
+      initiatives for, and manage the business of the Cooperative. As all Members are Managers, it is the intent of the
+      Cooperative that no Member is considered an employee of the Cooperative as a result of being a Member.</p>
+  </section>
+  <section id="d-2-the-executive-administration-committee">
+    <h3>2. The Executive Administration Committee (“EAC”)</h3>
+    <section id="d-2-a-general">
+      <h4>a. General</h4>
+      <p>In order to assist the Members in the administration of the Cooperative, the Members shall appoint an Executive
+        Administration Committee (the “EAC”) to provide administrative services. Except as otherwise provided by the
+        RULLCA, the EAC shall exercise such powers and perform such duties as specified in this Agreement and as
+        determined by the Members.</p>
+    </section>
+    <section id="d-2-b-eligibility-appointment-term">
+      <h4>b. Eligibility; Appointment; Term</h4> Any person serving on the EAC must be a current Member of the
+      Cooperative. The Members may set additional qualification and eligibility requirements for participation in the
+      EAC. The EAC shall have the number of seats, titles, and terms as are determined by the Members. The method for
+      electing or appointing members to the EAC shall be determined by the Members.
+    </section>
+    <section id="d-2-c-signing-authority">
+      <h4>c. Signing Authority</h4>
+      <p>Subject to the terms of this Agreement, for the purposes of clarity and administration, the signature of any
+        two members of the EAC acting in compliance with the provisions of this Agreement shall bind the Cooperative.
+      </p>
+    </section>
+  </section>
+  <section id="d-3-member-management-meetings">
+    <h3>3. Member Management Meetings</h3>
+    <p>The Members shall meet regularly for Management Meetings. Members may participate by telephone, skype, or another
+      similar mechanism. Management Meetings shall be monthly, and shall cover, among other topics, a report about
+      normal business operations from the previous Month, a report on finances, and planning upcoming events. No less
+      than each quarter, the Treasurer shall give a budget report which shall include an accounting of the Cooperative’s
+      expenses, revenues, and an update on the Member’s Capital Accounts, if applicable.</p>
+  </section>
+  <section id="d-4-voting">
+    <h3>4. Voting</h3>
+    <p id="d-4-a-one-vote-per-member">a. Each Member shall have one vote on each matter submitted for a vote. </p>
+    <p id="d-4-b-no-vote-pooling">b. Cumulative voting (i.e., pooling of votes) shall not be permitted for any purpose.
+    </p>
+    <p id="d-4-c-no-proxy-voting">c. Proxy voting shall not be permitted for any purpose. </p>
+    <p id="d-4-d-voting-processes">d. Unless otherwise specified, all votes shall be conducted using the processes in
+      Section F.3.</p>
+    <section id="d-4-e-ballots-shall">
+      <h4>e. Ballots</h4>
+      <p>Written ballots (including written ballots administered online) or personal voting may be used at any meeting
+        of Members. Personal voting may include, among other things, raising a hand or vocalizing a vote. If the ballot
+        is not written, a member of the EAC must record each vote and incorporate each vote into the meeting minutes.
+        Any written ballot used at a meeting shall:</p>
+      <p id="d-4-e-i-describe-proposal">i. Describe the proposal</p>
+      <p id="d-4-e-ii-provide-opportunity-to-approve-or-disapprove">ii. Provide an opportunity to approve or disapprove
+        the proposed action;</p>
+      <p id="d-4-e-ii-provide-opportunity-to-approve-or-disapprove">ii. Provide an opportunity to approve or disapprove
+        the proposed action; and</p>
+      <p id="d-4-e-iii-allowance-for-revokation-by-member">iii. State that unless revoked by the Member voting in person
+        at the meeting, the ballot will be counted if received by the Cooperative on or before the time of the meeting.
+      </p>
+    </section>
+    <p id="d-4-f-distribution-of-ballots"> f. When ballots are distributed at a meeting, the number of Members voting
+      shall be considered present for the purposes of determining quorum with respect to the specific actions in the
+      ballot.</p>
+  </section>
+  <section id="d-5-inability-to-attend-meetings">
+    <h3>5. Member Unable to Attend Meeting</h3>
+    <p>If a Member is unable to attend a meeting, then that Member must notify the other Members twenty-four (24) hours
+      prior to the commencement of the meeting. If the Member is unable to participate in the meeting in any form, then
+      that Member shall be responsible for reading the minutes and notes taken from that meeting. Each Member shall make
+      a good faith effort to attend each meeting.</p>
+    <section id="d-5-a-notice">
+      <h4>a. Notice</h4>
+      <p>Notice of a meeting shall be given to each Member by electronic transmission, or by mail or other means of
+        written communication. Notice to Members must be given no less than five (5) days before the date of the
+        meeting. The Cooperative shall also publicly display a calendar, whether physically or electronically, which
+        lists the date of the next meeting. The notice shall state the following:</p>
+      <p id="d-5-a-i-place-date-and-time"> i. Meeting place, date, and time of the meeting; </p>
+      <p id="d-5-a-ii-applicable-conferencing-information"> ii. If applicable, the log-in or call-in information for
+        telephone/video/web conference; and </p>
+      <p id="d-5-a-iii-special-meeting"> iii. In the case of a special meeting, the general nature of the business to be
+        transacted, and that no other business may be transacted. </p>
+    </section>
+    <p id="d-5-b-member-access-of-records"> b. Member access of records: The Cooperative shall ensure that all documents
+      related to the meetings, including minutes, notes, proposals, adopted policies and procedures, and ballots, shall
+      remain publicly available for the Cooperative and its Members. </p>
+  </section>
+</section>
+<pre>
+   :      6. Emergency Special
+  Meetings: a. An emergency meeting can only be called for a single decision item (not discussion item) that absolutely
+  cannot wait until the next scheduled meeting. b. Emergency meetings may be called by any two Members by giving notice to
+  the EAC. The EAC must schedule the emergency meeting within 72 hours of receiving notice. c. Notice of the emergency
+  meeting will be given by email or by individual text message or phone call to all Members. d. The Notice of the
+  emergency meeting shall include the decision item. e. Vote to Delay: The EAC may include with the Notice a binding vote
+  with the Notice on whether the question of whether the item can or cannot wait until the next scheduled meeting time. i.
+  If, at one hour before the emergency meeting, a majority of responses in the digital vote agrees that the meeting can
+  wait, no meeting will take place. ii. If an emergency meeting does not take place, this item will be added to the next
+  general meeting agenda. f. The agenda for an emergency meeting will be the emergency item only. g. An emergency meeting
+  can take place at the regular meeting place of the Cooperative or by conference call. 7. Proposals: All Members shall be
+  invited and welcomed to bring Proposals to the Cooperative. A Proposal includes, but is not limited to, any request to
+  change Cooperative policy, procedures, or processes, to engage in a new project, or to change the roles and positions of
+  Members. The EAC, in consultation with Members, will establish procedures for Members to bring a proposal to a vote. 8.
+  Adopting Time Sensitive Proposals Outside of Meetings: In the event that an opportunity or need arises, and 60% of the
+  Members agree that a Proposal needs to be considered quickly, then, if the Members are not in a meeting, the Members
+  shall vote on a Proposal and the Proposal shall pass with the approval of 80% of the Members. The EAC shall keep a
+  record of the proposal and outcome of the vote. If fewer than 60% of the Members agree that a decision is needed
+  quickly, then the Proposal shall be made at the next Member Meeting and shall be brought and considered in the manner in
+  which Proposals are required to be brought. 6 9. Quorum. The minimum number of Members needed to be at a meeting to make
+  decisions binding is referred to as “quorum.” The Cooperative intends for its Members to initiate and lead projects for
+  the Cooperative. It has therefore adopted a decision-making structure where most decisions can be made at a meeting with
+  a smaller quorum while major decisions require a higher quorum. a. Default Provisions: Unless designated a Major
+  Decision (as defined below), all proposals of the Cooperative may be considered and decided at a meeting with quorum of
+  fifty percent (50%) of the Membership in attendance. b. Major decisions: The following proposals require a quorum of at
+  least seventy percent (70%) of the Members in attendance: i. Getting a loan in amount of $50,000 or greater; ii.
+  Changing the Cooperative’s primary business; iii. Merging, selling, or dissolving the Cooperative; iv. Amending this
+  Agreement; and v. Entering the Cooperative into a financial obligation that exceeds $1,000. 10. Approving Proposals.
+  Unless otherwise specified in this Agreement (including Section F.9 below) or as required by law, all proposals shall be
+  approved by two-thirds (2/3rds) of the Members at a meeting with quorum. For illustration purposes only, here are some
+  examples of quorum and approval requirements: Default Decision Major Decision Total Members 13 13 Quorum required to
+  hold a meeting 7 (50% of 13, rounded up) 11. Unanimous Consent Required: 10 (70% of 13, rounded up) a. Amend this
+  Operating Agreement. The unanimous consent of the Members is required to amend this Operating Agreement. b. Acts outside
+  of the Ordinary Course of the Cooperative’s Activities. Pursuant to Section 17704.07(c)(4) of RULLCA (the California law
+  governing LLCs), the unanimous approval of the Members is required to take any activities outside the ordinary course of
+  the Cooperative’s activities, except as otherwise provided under Article 10 of RULLCA. Number of Votes to approve a
+  proposal with a minimum Quorum in attendance* 5 (2/3rds of 7) 7 (2/3rds of 10, rounded up) 7 (2/3rds of 10, rounded up)
+  Number of Votes to approve a proposal with 11 Members in attendance* 8 (2/3rds of 11) 8 (2/3rds of 11) 8 (2/3rds of 11)
+  *Note: Quorum is calculated based on the total number of all Members. If greater than the minimum quorum actually attend
+  a meeting, the votes required for approval are based on the actual number of Members in attendance, not the quorum
+  number. 7 12. Committees and Delegation: The Members may delegate the management of certain tasks and realms to
+  committees, and those committees shall meet separately from the Management Meetings. 13. Adopting Other Rules and
+  Policies: The Members may adopt other rules and policies outside of this Agreement. The Members shall record all other
+  rules and policies in a separate document that is provided to all Members, or they shall amend this Agreement to include
+  the new rules and policies. E. Cooperative Projects 1. Two Types of Cooperative Projects: The Cooperative will engage in
+  two distinct types of projects and will record patronage for separately for each type, as follows: a. Direct Client
+  Service Projects. i. Description: These projects shall typically be paid by a third-party client in exchange for
+  services from the Cooperative and its agents. Direct Client Service Projects will typically have a defined scope,
+  timeline, and negotiated rates with the third-party client. Contracts for Direct Client Service Projects shall typically
+  be between the third-party client and the Cooperative. ii. Consolidated Patronage Record: The Cooperative shall maintain
+  a consolidated record of all patronage by Members in support of all Direct Client Service Projects. b. Worker-Owned
+  Technology Projects. i. Description. Members of the Cooperative may choose to develop software programs, applications,
+  or other intellectual property for the purpose of commercialization, including but not limited to use in future Direct
+  Client Service Projects. The Cooperative anticipates that Worker-Owned Technology Projects shall have a longer timeline
+  for commercialization. ii. Distinct and Separate Patronage Records. The Cooperative seeks to simultaneously compensate
+  those Members who contribute to the research and development of intellectual property while also maintaining flexibility
+  for the Cooperative to determine the best means to commercialize any intellectual property. Therefore, for each
+  Worker-Owned Technology Project, the Cooperative shall maintain a record of each Member’s patronage for each
+  Worker-Owned Technology Project separately. We will keep written records of the date on which a product's development
+  began and all Members and the Cooperative will track their work hours on each product. If certain work cannot be
+  adequately pegged to a specific product, then the EAC, in consultation with the Members involved in the Worker-Owned
+  Technology Project, will make reasonable estimates of time allocations across products and document the basis for the
+  allocations. F. How Money is Managed in the Cooperative 1. Capital Accounts. a. Each Member will have an internal
+  account called the “Capital Account,” which generally represents an accounting of the Member’s contributions to and
+  distributions from the Cooperative and the Member’s share of the Cooperative’s net profits and net losses. In
+  particular, a Member’s Capital Account includes the total of the Member’s Capital Contributions in cash and the fair
+  market value of any property contributed to the Cooperative (net of any liabilities that the Cooperative assumes) plus
+  the Member’s share of Cooperative net profits, minus the amount of cash or the fair market value of any property 8 (net
+  of any liabilities that the Member assumes) distributed to the Member from the Cooperative and minus the Member’s share
+  of the Cooperative’s net losses. b. The Cooperative will maintain a separate Capital Account for each Member in
+  accordance with the capital account rules of Section 1.704-1(b)(2)(iv) of the Treasury Regulations, and this Operating
+  Agreement shall be interpreted and applied in a manner consistent with such Treasury Regulations. For this purpose, the
+  Cooperative may, upon the occurrence of the events specified in Treasury Regulations Section 1.704-1(b)(2)(iv)(f),
+  increase or decrease the Capital Accounts in accordance with the rules of such regulation and Treasury Regulations
+  Section 1.704-1(b)(2)(iv)(g) to reflect a revaluation of Cooperative property. c. For purposes of this Agreement, “net
+  profit” or “net loss” means the Cooperative’s taxable income or loss for federal income tax purposes for the applicable
+  period, as reasonably adjusted by the EAC in consultation with a qualified accountant or bookkeeper. 2. Taxes. a. It is
+  intended that the Cooperative be treated as a partnership for federal, state, and local income tax purposes. b. The
+  Members shall, individually, be responsible for paying federal, state, and any local income taxes attributable to their
+  share of the Cooperative’s net profits and losses, whether or not cash distributions are made by the Cooperative to the
+  Members. c. Members understand that all Cooperative income must be allocated to the Members’ Capital Accounts, and
+  acknowledge that they will need to pay taxes on the share of Cooperative income that is allocated to their Capital
+  Accounts, including income that has not been distributed to Members. In addition, Members are responsible for paying all
+  other taxes imposed on them individually, including quarterly self-employment taxes, as applicable. 3. Fiscal Year. The
+  fiscal year of the Cooperative for accounting and tax purposes shall begin on January 1 and end on December 31, except
+  for any shorter taxable years in the years of the Cooperative’s formation and termination. 4. Allocation of Profits. The
+  net profits of the Cooperative shall be allocated among the Members based on i) the type of Project; and ii) the
+  Member’s respective patronage for each project type, as follows: a. Direct Client Service Projects: Profits attributable
+  to all Direct Client Service Projects shall be allocated to the Member’s based on the consolidated patronage account
+  maintained in connection with these projects under Section E.1.a.ii above. b. Worker-Owned Technology Projects: The
+  Members agree and acknowledge that profits are not anticipated on Worker-Owned Technology projects until the
+  intellectual property can be successfully sold or licensed. When such profits are realized, they shall be divided among
+  all past and present worker-owners on the basis of the total number of hours each worker- owner put into the product's
+  development and marketing since the beginning of product development, consistent with the patronage records maintained
+  for each project under Section E.1.b.ii. 5. Retaining Earnings and Making Distributions. Distributions are cash or other
+  assets paid to Members from their Capital Accounts. On a quarterly basis, 30% of the Cooperative’s projected net profits
+  attributable to the quarter in question, as reasonably determined by the EAC in consultation with a qualified accountant
+  or bookkeeper, shall be distributed to the Members in the same manner that such net profits would be allocated to the
+  Members pursuant to Section F.4. The Cooperative shall not make distributions to the Members if doing so would leave the
+  Cooperative unable to pay its obligations and liabilities. A Member shall not be entitled to withdraw any part of the
+  Member’s Capital Contribution or to receive any distributions, whether of money or property, from the Cooperative except
+  as specifically provided in this Operating Agreement. 9 6. Sharing Losses. If the Cooperative has net losses, Members
+  will share those net losses in proportion to their Capital Accounts. 7. Additional Tax Matters. Except as otherwise
+  provided in this Operating Agreement, all items of Cooperative income, gain, loss, deduction and any other allocations
+  not otherwise provided for shall be allocated among the Members in the same manner as net profits and net losses under
+  Section F.4 and Section F.6, as the case may be. To the extent a Member shall have a negative Capital Account balance,
+  there shall be a qualified income offset, as set forth in Section 1.704- 1(b)(2)(ii)(d) of the Treasury Regulations.
+  Each item of income, gain, loss and deduction of the Cooperative for federal, state and local income tax purposes will
+  be allocated among the Members in the same manner as such income, gain, loss or deduction is allocated among the
+  Members’ Capital Accounts. Items of income, gain, loss and deduction of the Cooperative with respect to any property
+  contributed to the capital of the Cooperative shall be allocated among the Members in accordance with Section 704(c) of
+  the Internal Revenue Code of 1986, as amended (the “Code”), using any method allowed by Section 704(c) of the Code and
+  the Treasury Regulations thereunder selected by the EAC. The Members shall make appropriate amendments to the
+  allocations of items pursuant to this Section if necessary in order to comply with Section 704 of the Code and
+  applicable Treasury Regulations. 8. Tax Return Information. Within 90 days after the end of each taxable year, the
+  Cooperative shall send to each Member: a. the information necessary to complete federal and state income tax or
+  information returns; and b. a copy of the Cooperative’s federal, state, and local income tax or information returns for
+  the year, if available, and if not as soon as it is available. 9. Tax Administration. a. The Members and the Cooperative
+  acknowledge that the Cooperative is currently qualified under Section 6221(b) of the Code to elect out of the
+  centralized partnership audit regime rules of Subchapter C of Chapter 63 of the Code, and hereby agree that the
+  Cooperative shall make such election for all applicable tax years, in accordance with Section 6221(b) of the Code and
+  applicable Treasury Regulations for so long as it qualifies. b. In the event the Cooperative is required to appoint a
+  “Partnership Representative” within the meaning of Section 6223 of the Code (and any comparable provision of state or
+  local law, including as “tax matters partner”) with respect to a tax year of the Cooperative, the Chair or the Treasurer
+  of the EAC shall be the “Partnership Representative.” c. If applicable, the Partnership Representative: i. is authorized
+  and required to represent the Cooperative (at the Cooperative’s expense) in connection with all income tax examinations
+  of the Cooperative’s affairs by tax authorities; and ii. agrees not to settle or otherwise resolve any such examination
+  in a manner that would materially and adversely affect the Members without the prior written consent of any such
+  affected Members. d. If applicable, each Member agrees to cooperate with the Partnership Representative and the
+  Cooperative with respect to the conduct of such examinations. G. Record Keeping and Accounting 1. Member Information
+  Statements: Each Member shall complete a Member Information Statement and provide it to the Administrator. It is the
+  responsibility of the Member to provide a new 10 Statement to the Administrator any time the Member’s information
+  changes. The Member Information Statement form is provided in Exhibit B. 2. Required Record Keeping: At all times, the
+  Cooperative must maintain records of the following: a. Organizing and Governing Documents: An updated copy of the
+  Cooperative’s current Operating Agreement, Articles of Organization, and any rules or policies adopted by the Member
+  outside of this Agreement. b. Financial Information: Information regarding the financial condition of the Cooperative:
+  i. Profit and loss statements, prepared on a quarterly basis; ii. Balance sheets, prepared on a quarterly basis; iii.
+  Descriptions of the cash, bank account balances, and property of the Cooperative; iv. Patronage Records consistent with
+  Sections E.1.a.ii and E.1.b.ii; and v. Any contributions that Members have been agreed to make in the future. c. Tax
+  Returns: A copy of the federal, state, and local income taxes for each year, updated once available. d. Current Member
+  Information Statements: Copies of all updated Member Information Statements. e. Past Member List: A list of all past
+  Cooperative Members, including names, last known mailing address, phone number, email address, the Member’s designated
+  beneficiary for payment of the Member’s Capital Account upon death and for dissolution distributions, dates of
+  membership, and total number of hours worked during the membership. f. Meeting Records: A record of the minutes of
+  Management Meeting proceedings. 3. Member Rights to Inspect Records: Each Member has the right to demand and receive,
+  within a reasonable period of time, a copy of any of the above documents for any purpose reasonably related to their
+  interest as a Member of the Cooperative. If a member would like a copy to keep, that Member shall pay for the copying
+  expenses. The inspection may be made in person by the Member, or by an agent or attorney for the Member. 4. Annual
+  Report: The Treasurer shall prepare, and all Members must receive, a copy of the annual report, prepared no later than
+  120 days after the end of the Cooperative’s fiscal year. The annual report must contain: a. A balance sheet; b. A
+  detailed profit and loss statement for the full fiscal year; c. A statement of all debts of the Cooperative; d. A
+  description of the basis on which each Member’s share of patronage or Loss was determined. H. How to Terminate
+  Membership in The Cooperative 1. Voluntary Resignation. A Member may withdraw from the Cooperative at any time upon
+  written notice to the EAC. 2. Involuntary Termination: A Member is subject to withdrawal or expulsion from the
+  Cooperative under the following circumstances: a. Death b. Performing no services for either a Direct Client Services
+  Project or a Worker-Owned Technology Project for six (6) consecutive months unless that Member gives notice to the 11
+  EAC of an illness or disability that may prevent the Member from performing such services for no more than nine (9)
+  months or under such other circumstances as are approved by the EAC; or c. Failure to achieve a Vote of Confidence. 3.
+  Vote of Confidence: A Member may be expelled from the Cooperative based on a “Vote of Confidence” with respect to any
+  Member’s status as a Member in the Cooperative if the Vote of Confidence is not approved. a. Violations that may trigger
+  a Vote of Confidence include i. committing physical or verbal acts of violence against a Member or other persons related
+  to the Cooperative; ii. using Cooperative resources or funds for personal benefit without the Members’ approval; iii.
+  Conviction of any felony; iv. Violating the terms of a client agreement, this Agreement, or the Cooperative’s Code of
+  Conduct. b. A Vote of Confidence on a Member who committed a violation (the “Violating Member”) requires the affirmative
+  vote of 80% of the membership for approval, not including the Violating Member. c. Where a Vote of Confidence regarding
+  a Violating Member has failed, the membership of such Member shall be terminated. d. Upon notice of a violation that
+  would trigger a Vote of Confidence, the EAC shall give notice to the Members of the reason(s) for the Vote of Confidence
+  and no less than fourteen (14) days for the Members to submit their votes. Where a Member declines to submit a vote in
+  response to such notice, it shall be considered a vote of no confidence. e. Specifically, the EAC shall send notice to
+  the Members that includes at minimum the following information: i. name of the Member subject to a Vote of Confidence
+  ii. a brief description of the triggering event prepared by the EAC; iii. A statement from the Member, if desired,
+  disputing the triggering event iv. At the EAC’s option, a response from the EAC to the Member’s dispute of the
+  triggering event. 4. Rights upon Termination. a. No Further Activities. Termination of membership automatically removes
+  an individual from all positions in the Cooperative, including but not limited to any committee of the Cooperative. b.
+  No Waiver of Liabilities. A Member whose membership in the Cooperative is terminated shall be liable for any charges,
+  dues, or other obligations incurred before the termination. c. Conversion of Membership to Loan. When a Member ends her
+  membership voluntarily or involuntarily (except in the case of death, see below), that Member’s Capital Account and
+  other debts the Cooperative owes the Member become a loan to the Cooperative. That loan must be paid to the Member
+  within five years. The loan shall not accumulate interest during the first year. After the first year, it will
+  accumulate interest at an APR of 3% on the outstanding amount. If funds are available and, with approval by at least 75%
+  of the Members, the Cooperative may elect to pay the Member within 30 days of when she leaves. There shall be no fee or
+  penalty for prepayment of such loan by the Cooperative. d. Designated Beneficiary in case of Death. If a Member passes
+  away, the payment will go to the Member’s Designated Beneficiary(ies), whose name appears in the Statement of
+  Information of that Member. If a Member has passed away and has not named a 12 Designated Beneficiary, or if the
+  Cooperative cannot find the ex‐Member or Designated Beneficiary after reasonable effort, the Cooperative will not be
+  obliged to distribute to that Member, her Designated Beneficiary, or any other heir or beneficiary of that Member. I.
+  How to Resolve Conflicts 1. When a conflict arises between Members or between a Member and the Cooperative that cannot
+  be resolved through good faith discussion, either party may elect to submit to binding arbitration. The venue for
+  arbitration shall be agreed to by the parties to the arbitration, or if the parties cannot agree, at a venue selected by
+  the EAC. 2. All arbitration decisions shall be final, binding and conclusive on all the parties to arbitration, and
+  legal judgment may be entered based upon such decision in accordance with applicable law in any court having
+  jurisdiction to do so. 3. The opposing parties shall agree to each pay half the cost of binding arbitration procedures.
+  J. Additional Provisions 1. Complete Agreement: This Agreement and the Articles of Organization constitute the complete
+  and exclusive statement of the Members with respect to the subject matter herein and therein and replace and supersede
+  all prior written and oral agreements or statements by the Members. If there is any conflict between the provisions of
+  this Agreement and the Articles of Organization, then the provisions of this Agreement, to the extent permitted under
+  California law, shall control. 2. Mandatory Review of Operating Agreement: Upon the occurrence of any of the following
+  events, the Cooperative will appoint a committee to review and recommend to the Cooperative amendments to this
+  Agreement. The committee must deliver its recommendations at a Monthly Member Meeting no less than six (6) months after
+  the occurrence of the triggering event. a. A change in the Approved Purpose of the Cooperative. b. When the total number
+  of Members reaches twelve (12). c. When total revenues from Worker-Owned Technology Projects exceeds $100,000. 3. If a
+  Member is Sued by Someone Outside of the Cooperative: All Members will be indemnified and held harmless by the
+  Cooperative from and against any and all claims of any nature arising out of a Member's participation in Cooperative
+  affairs. A Member will not be entitled to indemnification under this section for liability arising out of gross
+  negligence or willful misconduct of the Member or the breach by the Member of any provisions of this Agreement. This
+  means, for example, that the Cooperative will compensate and help to defend a Member who is sued for damages that occur
+  when the Member is working for the Cooperative. 4. Members Will Not Be Liable for Good Faith Mistakes: If a Member is
+  acting in good faith and in service of the Cooperative, and if she makes a mistake or error in judgment, or commits an
+  unintentional act or omission, the Member will not be liable to the Cooperative or to any other Member for the mistake
+  or error. The Member will be liable only for acts and omissions involving intentional wrongdoing. 5. Gender Pronouns:
+  Even though we typically use “she” and “her” throughout this Agreement, these words should be interpreted to mean “he,
+  she, or they” or “his, her, or their.” 13 6. The Bold Headings Are Not a Legally Binding Part of This Agreement: We have
+  included very descriptive headings in this Agreement, in order to make it easy to read and navigate. However, these bold
+  headings shall not be considered to be a legally binding part of this Agreement. 7. How to Provide Notice to Members:
+  Any time that a Member or the Cooperative is required to give notice to the Members, the notice shall be given by any of
+  the following methods: 1) Notice may be mailed to the physical addresses of the Members, in which case notice shall be
+  considered given three business days after place the notice in the mail with first class postage; 2) Notice may be
+  delivered by email or text to the email addresses and phone numbers provided by Members, in which case notice shall be
+  considered delivered when the member replies to the email and acknowledges receipt; 3) Notice may be delivered in
+  person, in which case notice shall be considered delivered when the notice is placed in the hands of the Member, and 4)
+  Notice may be delivered by telephone, in which case notice shall be considered delivered when the receiving Member
+  voices acknowledgment of the notice. 8. Severability: If any provision of this Agreement is held by a court to be
+  invalid or unenforceable, Members agree that the provision shall be reduced in scope by the court only to the extent
+  deemed necessary by that court to render the provision reasonable and enforceable, and the remaining provisions of this
+  Agreement will not be affected or invalidated as a result. 9. This Agreement is Binding on Successors: This Agreement
+  and the terms and conditions contained in this Agreement apply to and are binding upon the Member's successors, assigns,
+  executors, administrators, beneficiaries, and representatives. the Members hereby agree to all of the terms and
+  conditions in this Agreement.
+</pre>
 <footer>
   <a href="https://drive.google.com/file/d/1f45o0cz769fpJDSrypvk579CL5Iwi8St/view?usp=sharing">PDF</a>
 </footer>

--- a/src/operating-agreement/index.html
+++ b/src/operating-agreement/index.html
@@ -267,53 +267,100 @@
       related to the meetings, including minutes, notes, proposals, adopted policies and procedures, and ballots, shall
       remain publicly available for the Cooperative and its Members. </p>
   </section>
+  <section id="d-6-emergency-special-meetings">
+    <h3>6. Emergency Special Meetings</h3>
+    <p id="d-6-a-purpose-of-emergency-meetings"> a. An emergency meeting can only be called for a single decision item
+      (not discussion item) that absolutely cannot wait until the next scheduled meeting. </p>
+    <p id="d-6-b-calling-emergency-meetings"> b. Emergency meetings may be called by any two Members by giving notice to
+      the EAC. The EAC must schedule the emergency meeting within 72 hours of receiving notice. </p>
+    <p id="d-6-c-notice-to-members"> c. Notice of the emergency meeting will be given by email or by individual text
+      message or phone call to all Members.</p>
+    <p id="d-6-d-inclusion-of-purpose-in-notice"> d. The Notice of the emergency meeting shall include the decision
+      item. </p>
+    <section id="d-6-e-vote-to-delay">
+      <h4>e. Vote to Delay</h4>
+      <p> The EAC may include with the Notice a binding vote with the Notice on whether the question of whether the item
+        can or cannot wait until the next scheduled meeting time.</p>
+      <p id="d-6-e-i-trigger-to-delay">i. If, at one hour before the emergency meeting, a majority of responses in the
+        digital vote agrees that the meeting can wait, no meeting will take place.</p>
+      <p id="d-6-e-ii-addition-to-next-meeting-agenda"> ii. If an emergency meeting does not take place, this item will
+        be added to the next general meeting agenda. </p>
+    </section>
+    <p id="d-6-f-agenda-of-emergency-meeting"> f. The agenda for an emergency meeting will be the emergency item only.
+    </p>
+    <p id="d-6-g-location-of-emergency-meeting"> g. An emergency meeting can take place at the regular meeting place of
+      the Cooperative or by conference call. </p>
+  </section>
+  <section id="d-7-proposals">
+    <h3>7. Proposals</h3>
+    <p>All Members shall be invited and welcomed to bring Proposals to the Cooperative. A Proposal includes, but is not
+      limited to, any request to change Cooperative policy, procedures, or processes, to engage in a new project, or to
+      change the roles and positions of Members. The EAC, in consultation with Members, will establish procedures for
+      Members to bring a proposal to a vote.</p>
+  </section>
+  <section id="d-8-adopting-proposals-outside-of-meetings">
+    <h3>8. Adopting Time Sensitive Proposals Outside of Meetings</h3>
+    <p>In the event that an opportunity or need arises, and 60% of the Members agree that a Proposal needs to be
+      considered quickly, then, if the Members are not in a meeting, the Members shall vote on a Proposal and the
+      Proposal shall pass with the approval of 80% of the Members. The EAC shall keep a record of the proposal and
+      outcome of the vote. If fewer than 60% of the Members agree that a decision is needed quickly, then the Proposal
+      shall be made at the next Member Meeting and shall be brought and considered in the manner in which Proposals are
+      required to be brought.</p>
+  </section>
+  <section id="d-9-quorum">
+    <h3>9. Quorum</h3>
+    <p>The minimum number of Members needed to be at a meeting to make decisions binding is referred to as “quorum.” The
+      Cooperative intends for its Members to initiate and lead projects for the Cooperative. It has therefore adopted a
+      decision-making structure where most decisions can be made at a meeting with a smaller quorum while major
+      decisions require a higher quorum.</p>
+    <section id="d-9-a-default-provisions">
+      <h4>a. Default Provisions</h4>
+      <p>Unless designated a Major Decision (as defined below), all proposals of the Cooperative may be considered and
+        decided at a meeting with quorum of fifty percent (50%) of the Membership in attendance.</p>
+    </section>
+    <section id="d-9-b-major-decisions">
+      <h4>b. Major decisions</h4>
+      <p>The following proposals require a quorum of at least seventy percent (70%) of the Members in attendance:</p>
+      <p id="d-9-b-i-gettin-a-loan"> i. Getting a loan in amount of $50,000 or greater; </p>
+      <p id="d-9-b-ii-changing-primary-business">ii. Changing the Cooperative’s primary business;</p>
+      <p id="d-9-b-iii-merging-selling-or-dissolving">iii. Merging, selling, or dissolving the Cooperative;</p>
+      <p id="d-9-b-iv-amending-agreement">iv. Amending this Agreement; and</p>
+      <p id="d-9-b-v-entering-financial-obligations">v. Entering the Cooperative into a financial obligation that
+        exceeds $1,000.</p>
+    </section>
+  </section>
+  <section id="d-10-approving-proposals">
+    <h3>10. Approving Proposals</h3>
+    <p>Unless otherwise specified in this Agreement (including Section F.9 below) or as required by law, all proposals
+      shall be approved by two-thirds (2/3rds) of the Members at a meeting with quorum.</p>
+  </section>
+  <section id="d-11-unanimous-consent-required">
+    <h3>11. Unanimous Consent Required</h3>
+    <section id="d-11-a-amending-operating-agreement">
+      <h4>a. Amend this Operating Agreement</h4>
+      <p>The unanimous consent of the Members is required to amend this Operating Agreement.</p>
+    </section>
+    <section id="d-11-b-acts-outside-ordinary-course-of-activities">
+      <h4> b. Acts outside of the Ordinary Course of the Cooperative’s Activities</h4>
+      <p>Pursuant to Section 17704.07(c)(4) of RULLCA (the California law governing LLCs), the unanimous approval of the
+        Members is required to take any activities outside the ordinary course of the Cooperative’s activities, except
+        as otherwise provided under Article 10 of RULLCA.</p>
+    </section>
+  </section>
+  <section id="d-12-committees-and-delegation">
+    <h3>12. Committees and Delegation</h3>
+    <p>The Members may delegate the management of certain tasks and realms to committees, and those committees shall
+      meet separately from the Management Meetings.</p>
+  </section>
+  <section id="d-13-adopting-other-rules">
+    <h3>13. Adopting Other Rules and Policies</h3>
+    <p>The Members may adopt other rules and policies outside of this Agreement. The Members shall record all other
+      rules and policies in a separate document that is provided to all Members, or they shall amend this Agreement to
+      include the new rules and policies.</p>
+  </section>
 </section>
 <pre>
-   :      6. Emergency Special
-  Meetings: a. An emergency meeting can only be called for a single decision item (not discussion item) that absolutely
-  cannot wait until the next scheduled meeting. b. Emergency meetings may be called by any two Members by giving notice to
-  the EAC. The EAC must schedule the emergency meeting within 72 hours of receiving notice. c. Notice of the emergency
-  meeting will be given by email or by individual text message or phone call to all Members. d. The Notice of the
-  emergency meeting shall include the decision item. e. Vote to Delay: The EAC may include with the Notice a binding vote
-  with the Notice on whether the question of whether the item can or cannot wait until the next scheduled meeting time. i.
-  If, at one hour before the emergency meeting, a majority of responses in the digital vote agrees that the meeting can
-  wait, no meeting will take place. ii. If an emergency meeting does not take place, this item will be added to the next
-  general meeting agenda. f. The agenda for an emergency meeting will be the emergency item only. g. An emergency meeting
-  can take place at the regular meeting place of the Cooperative or by conference call. 7. Proposals: All Members shall be
-  invited and welcomed to bring Proposals to the Cooperative. A Proposal includes, but is not limited to, any request to
-  change Cooperative policy, procedures, or processes, to engage in a new project, or to change the roles and positions of
-  Members. The EAC, in consultation with Members, will establish procedures for Members to bring a proposal to a vote. 8.
-  Adopting Time Sensitive Proposals Outside of Meetings: In the event that an opportunity or need arises, and 60% of the
-  Members agree that a Proposal needs to be considered quickly, then, if the Members are not in a meeting, the Members
-  shall vote on a Proposal and the Proposal shall pass with the approval of 80% of the Members. The EAC shall keep a
-  record of the proposal and outcome of the vote. If fewer than 60% of the Members agree that a decision is needed
-  quickly, then the Proposal shall be made at the next Member Meeting and shall be brought and considered in the manner in
-  which Proposals are required to be brought. 6 9. Quorum. The minimum number of Members needed to be at a meeting to make
-  decisions binding is referred to as “quorum.” The Cooperative intends for its Members to initiate and lead projects for
-  the Cooperative. It has therefore adopted a decision-making structure where most decisions can be made at a meeting with
-  a smaller quorum while major decisions require a higher quorum. a. Default Provisions: Unless designated a Major
-  Decision (as defined below), all proposals of the Cooperative may be considered and decided at a meeting with quorum of
-  fifty percent (50%) of the Membership in attendance. b. Major decisions: The following proposals require a quorum of at
-  least seventy percent (70%) of the Members in attendance: i. Getting a loan in amount of $50,000 or greater; ii.
-  Changing the Cooperative’s primary business; iii. Merging, selling, or dissolving the Cooperative; iv. Amending this
-  Agreement; and v. Entering the Cooperative into a financial obligation that exceeds $1,000. 10. Approving Proposals.
-  Unless otherwise specified in this Agreement (including Section F.9 below) or as required by law, all proposals shall be
-  approved by two-thirds (2/3rds) of the Members at a meeting with quorum. For illustration purposes only, here are some
-  examples of quorum and approval requirements: Default Decision Major Decision Total Members 13 13 Quorum required to
-  hold a meeting 7 (50% of 13, rounded up) 11. Unanimous Consent Required: 10 (70% of 13, rounded up) a. Amend this
-  Operating Agreement. The unanimous consent of the Members is required to amend this Operating Agreement. b. Acts outside
-  of the Ordinary Course of the Cooperative’s Activities. Pursuant to Section 17704.07(c)(4) of RULLCA (the California law
-  governing LLCs), the unanimous approval of the Members is required to take any activities outside the ordinary course of
-  the Cooperative’s activities, except as otherwise provided under Article 10 of RULLCA. Number of Votes to approve a
-  proposal with a minimum Quorum in attendance* 5 (2/3rds of 7) 7 (2/3rds of 10, rounded up) 7 (2/3rds of 10, rounded up)
-  Number of Votes to approve a proposal with 11 Members in attendance* 8 (2/3rds of 11) 8 (2/3rds of 11) 8 (2/3rds of 11)
-  *Note: Quorum is calculated based on the total number of all Members. If greater than the minimum quorum actually attend
-  a meeting, the votes required for approval are based on the actual number of Members in attendance, not the quorum
-  number. 7 12. Committees and Delegation: The Members may delegate the management of certain tasks and realms to
-  committees, and those committees shall meet separately from the Management Meetings. 13. Adopting Other Rules and
-  Policies: The Members may adopt other rules and policies outside of this Agreement. The Members shall record all other
-  rules and policies in a separate document that is provided to all Members, or they shall amend this Agreement to include
-  the new rules and policies. E. Cooperative Projects 1. Two Types of Cooperative Projects: The Cooperative will engage in
+    E. Cooperative Projects 1. Two Types of Cooperative Projects: The Cooperative will engage in
   two distinct types of projects and will record patronage for separately for each type, as follows: a. Direct Client
   Service Projects. i. Description: These projects shall typically be paid by a third-party client in exchange for
   services from the Cooperative and its agents. Direct Client Service Projects will typically have a defined scope,

--- a/src/operating-agreement/index.html
+++ b/src/operating-agreement/index.html
@@ -1,0 +1,602 @@
+<header>
+  <h1>Operating Agreement of Zinc Collective, LLC, a California Limited Liability Company</h1>
+
+  <section class="preamble">
+    <p>To produce software requires only imagination, thoughtful work, and the empathy to truly understand the needs of
+      others.</p>
+
+    <p>Zinc exists so all who contribute to the design, development, maintenance and distribution of software may derive
+      permanent economic benefit from the software they create.</p>
+
+    <p>Zinc seeks to create long term and immediate economic and ecological security for its members through the
+      practical
+      and equitable decentralization of power.</p>
+
+    <p>The Members (the “Members”) of Zinc Collective, LLC (the “Cooperative”) enter into this Operating Agreement,
+      effective as of 1st October 2019, 2019 to provide for the governance and operations of the Cooperative and to
+      specify the Members’ rights and obligations.</p>
+  </section>
+
+  <section id="recitals">
+    <h2>Recitals</h2>
+    <p>WHEREAS, the Members of the Cooperative have chosen to operate as a worker cooperative because they believe
+      that worker cooperatives contribute to a more just society and to more just and healthy workplaces.</p>
+    <p>WHEREAS, the Members desire to enter into a written agreement pursuant to the California Act to establish their
+      rights and responsibilities, to govern their relationships and to govern the affairs of the Cooperative and the
+      conduct of its business, and hereby agree as follows:</p>
+  </section>
+</header>
+<section id="a-general-provisions">
+  <h2>A. General Provisions</h2>
+  <section id="a-1-name-place-of-business-and-agent">
+    <h3>1. Name, Place of Business, and Agent</h3>
+    <p>The name of the Cooperative is Zinc Collective, LLC. Its principal place of business shall be such place in
+      California as the Members may hereafter determine. Its resident agent in the State of California shall be
+      determined by the EAC.</p>
+  </section>
+
+  <section id="a-2-purpose">
+    <h3>2. Purpose</h3>
+    <p>The purpose of the Cooperative shall be, and such additional activities in furtherance of the foregoing as may be
+      unanimously approved in advance by the Members (collectively and
+      severally the “Approved Purpose”) and, without limiting the foregoing, to engage in any lawful activity for which
+      limited liability companies may be formed under the California Revised Uniform Limited Liability Company Act (the
+      “Act”).</p>
+  </section>
+
+  <section id="a-3-term-of-cooperative">
+    <h3>3. Term of Cooperative</h3>
+    <p>The term of the Cooperative shall commence the date the Articles of Organization were
+      filed with the California Secretary of State and shall continue on a perpetual basis unless dissolved pursuant to
+      this Agreement or the Act.</p>
+  </section>
+</section>
+<section id="b-membership">
+  <h2>B. Membership</h2>
+  <section id="b-1-classes-of-members">
+    <h3>1. Classes of Members</h3>
+    <p>The Cooperative shall have one class of Members.</p>
+  </section>
+
+  <section id="b-2-becoming-a-member">
+    <h3>2. Becoming a Member</h3>
+    <p>To become a Member of this Cooperative, a person seeking membership (a “Prospective Member”) must:</p>
+    <section id="b-2-a-work-for-the-cooperative">
+      <h4>a. Work for The Cooperative</h4>
+      <p>A Prospective Member must work for the Cooperative for a minimum of 120 hours over a period of 12 consecutive
+        months prior to becoming a Member.</p>
+    </section>
+
+    <section id="b-2-b-work-with-different-members">
+      <h4>b. Work with Different Members</h4>
+      <p>A Prospective Member must directly work with or collaborate with at least two (2) current members.</p>
+    </section>
+
+    <section id="b-2-c-take-part-in-leadership-training">
+      <h4>c. Take Part in Leadership Training</h4>
+      <p>Every Prospective Member must take part in leadership or entrepreneurial training and provide a certificate of
+        her completion of such training to the Cooperative. Examples of acceptable trainings include trainings on
+        cooperative organizations, or programs that build the
+        leadership and entrepreneurial skills of the Prospective Member.</p>
+    </section>
+    <section id="b-2-d-make-a-written-request-to-become-a-member">
+      <h4>d. Make a Written Request to Become a Member</h4>
+      <p>A Prospective Member must write a brief request to become a Member, explaining why they would like to become a
+        Member.</p>
+    </section>
+
+    <section id="b-2-e-approval-by-the-eac-and-the-members">
+      <h4>e. Approval by the EAC and the Members</h4>
+      <p>A Prospective Member must be approved by the EAC (as defined below) and the Members, by means of the process
+        described in Section B.3, below.</p>
+    </section>
+    <section id="b-2-f-make-a-capital-contribution">
+      <h4>f. Make a Capital Contribution</h4>
+      <p>A Prospective Member must contribute $2,000 to the Cooperative. This is called a Capital Contribution. If the
+        Members approve, a Prospective Member may make her required Capital Contribution by contributing something other
+        than money, such as services or equipment, or by making payments over time, after she becomes a Member.</p>
+    </section>
+  </section>
+
+  <section id="b-3-acceptance-of-members">
+    <h3>3. Acceptance of Members</h3>
+    <p>The application review and approval process for a Prospective Member is
+      as follows:</p>
+    <p id="b-3-a-designation-of-member-advisor">a. Upon receipt of a Written Request by a Prospective Member to become a
+      Member, the EAC will designate a “Member
+      Advisor”, to advise the Prospective Member of the process of becoming a Member, to review the Prospective Member’s
+      Written Request, and verify that the Prospective Member has completed the requirements of Section C.2.a through
+      C.2.d, above. The Member Advisor must be a current Member but is not required to be a Manager or Officer.
+    </p>
+    <p id="b-3-b-confirmation-of-eligibility">b. Once the Member Advisor has confirmed that the Prospective Member has
+      completed the requirements necessary to be eligible for membership, the Member Advisor will place the Prospective
+      Member’s candidacy on the EAC’s agenda within thirty (30) days.</p>
+
+    <p id="b-3-c-confirmation-of-eligibility">c. At a meeting of the EAC of the Cooperative, the EAC must unanimously
+      vote to accept the Prospective Member as a new Member of the Cooperative. The vote shall be held without the
+      Prospective Member in the room. Members of the EAC voting “No” shall be asked to explain themselves.</p>
+    <section id="b-3-d-process-of-non-objection">
+      <p>d. Following approval by the EAC, the Members must approve the
+        admission of a Prospective Member through a process of non-objection. Specifically, the EAC shall send notice to
+        the Members that includes at minimum the following information:</p>
+      <p id="b-3-d-i-name-of-member">i. name of the Prospective Member</p>
+      <p id="b-3-d-ii-a-brief-description-of-their-work">ii. name of the Prospective Member</p>
+      <p id="b-3-d-iii-name-of-collaborated-workers">iii. the names of the Members with whom the Prospective Member has
+        collaborated</p>
+      <p id="b-3-d-iv-hours-and-months-worked">iv. the hours and months in which the Prospective Member has worked</p>
+      <p id="b-3-d-v-name-of-membership-advisor">v. the name of the Membership Advisor.,</p>
+    </section>
+
+    <p id="b-3-e-objection-period-and-threshold">e. Following the notice described, current Members may raise an
+      objection within
+      seven (7) days. Unless twenty five percent (25%) or more of the existing Members object to the admission of the
+      Prospective Member in writing to the EAC within the stated deadline, for any reason or no reason, then Prospective
+      Member shall be admitted as a Member.</p>
+
+    <p id="b-3-f-return-of-capital-contribution">f. If the EAC declines to approve a Prospective Member or if twenty
+      five percent
+      (25%) or more of the existing Members object to the admission of the Prospective Member within the stated
+      deadline, then
+      the Prospective Member shall not be admitted as a Member, and the Cooperative shall return any of the Prospective
+      Member’s Initial Capital Contribution.</p>
+    <p id="b-3-g-timing-of-membership">g. If the Prospective Member is approved by the EAC and the Members, and upon
+      meeting all of the qualifications of Section A(2) above, the Prospective Member shall immediately become a Member.
+    </p>
+  </section>
+
+  <section id="b-4-former-members">
+    <h3>4. Former Members</h3>
+    <p>If a former Member seeks to be reinstated as a Member, the EAC may by unanimous vote waive the candidacy period
+      and application process and renew a former Member’s Membership.</p>
+  </section>
+
+  <section id="b-5-no-transfers-of-membership">
+    <h3>5. No Transfers of Membership.</h3>
+    <p>No Member may transfer her Membership or any right
+      arising from that Membership. Any attempted assignment or transfer of Membership shall be void and will not confer
+      rights on the intended assignee or transferee.</p>
+  </section>
+</section>
+
+<section id="c-member-rights-and-duties">
+  <h2>C. Member Rights and Duties</h2>
+  <section id="c-1-duty-to-devote-time">
+    <h3>1. Duty to Devote Time:</h3>
+    <p>Subject to the participation minimums contained in Section H.2.b, each Member shall devote
+      such time and attention to the Cooperative as he or she chooses. There shall be no requirement that Members
+      contribute an equal amount of time to the Cooperative.</p>
+  </section>
+
+  <section id="c-2-right-to-work">
+    <h3>2. Right to Work:</h3>
+    <p>Members acknowledge that work opportunities may fluctuate
+      with the Cooperative’s business needs, and that the practical needs of the business may mandate that certain Members
+      work more than others. However, Members agree to strive to offer all Members the opportunity to work and earn money in
+      the Cooperative.</p>
+  </section>
+</section>
+
+3. Duty to Attend Meetings: Members shall strive to attend each Monthly Member Meeting. 4. Duty of
+Confidentiality: Due to the nature of its business, confidentiality is important to the Cooperative, the Members, and
+Cooperative clients. From time to time, Members may learn information about the Cooperative, its clients, its client
+projects, and research and development projects of the Cooperative that is sensitive or proprietary information
+(collectively, “Confidential Information”). Confidential Information shall not include information that, at the time
+of
+disclosure:
+a. is or becomes generally available to and known by the public other than as a result of,
+directly or indirectly, any breach of this Section by the Members; b. is or becomes available to a Member on a
+non-confidential basis from a third-party source,
+provided that such third party is not and was not prohibited from disclosing such Confidential Information; c. was
+known
+by or in the possession of the Member before being disclosed or learned through
+the Cooperative; or d. is required to be disclosed under applicable federal, state or local law, regulation or a valid
+order issued by a court or governmental agency of competent jurisdiction. In furtherance of the foregoing, each Member
+shall: (A) protect and safeguard the confidentiality of all Confidential Information with at least the same degree of
+care as she would protect her own Confidential Information, but in no event with less than a commercially reasonable
+degree of care; (B) not use any Confidential Information, or permit it to be accessed or used, for any purpose other
+than to exercise her rights or perform its obligations under this Agreement; and (C) not disclose any such
+Confidential
+Information to any person or entity, except to other Members or Cooperative representatives who need to know the
+Confidential Information to assist the Member, or act on its behalf, to exercise its rights or perform its obligations
+under the Agreement. A Member shall be responsible for any breach of this Section caused by that Member or her
+representatives. Members shall promptly return or destroy all copies of Confidential Information upon termination of
+her
+4
+membership. In addition to all other remedies available at law, the Cooperative may seek equitable relief (including
+injunctive relief) against a Member or her representatives to prevent the breach or threatened breach of this Section
+and to secure its enforcement. D. How to Govern and Manage the Cooperative
+1. All Members of the Cooperative shall be Managers: All Members shall be Managers of the Cooperative. It is the
+intent
+of the Members to actively engage in, lead initiatives for, and manage the business of the Cooperative. As all Members
+are Managers, it is the intent of the Cooperative that no Member is considered an employee of the Cooperative as a
+result of being a Member. 2. The Executive Administration Committee (“EAC”).
+a. General: In order to assist the Members in the administration of the Cooperative, the Members shall appoint an
+Executive Administration Committee (the “EAC”) to provide administrative services. Except as otherwise provided by the
+RULLCA, the EAC shall exercise such powers and perform such duties as specified in this Agreement and as determined by
+the Members. b. Eligibility; Appointment; Term: Any person serving on the EAC must be a current Member of the
+Cooperative. The Members may set additional qualification and eligibility requirements for participation in the EAC.
+The
+EAC shall have the number of seats, titles, and terms as are determined by the Members. The method for electing or
+appointing members to the EAC shall be determined by the Members. c. Signing Authority: Subject to the terms of this
+Agreement, for the purposes of clarity and administration, the signature of any two members of the EAC acting in
+compliance with the provisions of this Agreement shall bind the Cooperative. 3. Member Management Meetings: The
+Members
+shall meet regularly for Management Meetings. Members may participate by telephone, skype, or another similar
+mechanism.
+Management Meetings shall be monthly, and shall cover, among other topics, a report about normal business operations
+from the previous Month, a report on finances, and planning upcoming events. No less than each quarter, the Treasurer
+shall give a budget report which shall include an accounting of the Cooperative’s expenses, revenues, and an update on
+the Member’s Capital Accounts, if applicable. 4. Voting:
+a. Each Member shall have one vote on each matter submitted for a vote. b. Cumulative voting (i.e., pooling of votes)
+shall not be permitted for any purpose. c. Proxy voting shall not be permitted for any purpose. d. Unless otherwise
+specified, all votes shall be conducted using the processes in Section F.3. e. Ballots. Written ballots (including
+written ballots administered online) or personal voting may be used at any meeting of Members. Personal voting may
+include, among other things, raising a hand or vocalizing a vote. If the ballot is not written, a member of the EAC
+must
+record each vote and incorporate each vote into the meeting minutes. Any written ballot used at a meeting shall:
+i. Describe the proposal; ii. Provide an opportunity to approve or disapprove the proposed action; and iii. State that
+unless revoked by the Member voting in person at the meeting, the ballot will be counted if received by the
+Cooperative
+on or before the time of the meeting. f. When ballots are distributed at a meeting, the number of Members voting shall
+be considered present for the purposes of determining quorum with respect to the specific actions in the ballot.
+5
+5. Member Unable to Attend Meeting: If a Member is unable to attend a meeting, then that Member must notify the other
+Members twenty-four (24) hours prior to the commencement of the meeting. If the Member is unable to participate in the
+meeting in any form, then that Member shall be responsible for reading the minutes and notes taken from that meeting.
+Each Member shall make a good faith effort to attend each meeting.
+a. Notice: Notice of a meeting shall be given to each Member by electronic transmission, or by mail or other means of
+written communication. Notice to Members must be given no less than five (5) days before the date of the meeting. The
+Cooperative shall also publicly display a calendar, whether physically or electronically, which lists the date of the
+next meeting. The notice shall state the following:
+i. Meeting place, date, and time of the meeting; ii. If applicable, the log-in or call-in information for
+telephone/video/web conference;
+and iii. In the case of a special meeting, the general nature of the business to be
+transacted, and that no other business may be transacted. b. Member access of records: The Cooperative shall ensure
+that
+all documents related to the meetings, including minutes, notes, proposals, adopted policies and procedures, and
+ballots, shall remain publicly available for the Cooperative and its Members. 6. Emergency Special Meetings:
+a. An emergency meeting can only be called for a single decision item (not discussion item)
+that absolutely cannot wait until the next scheduled meeting. b. Emergency meetings may be called by any two Members
+by
+giving notice to the EAC. The
+EAC must schedule the emergency meeting within 72 hours of receiving notice. c. Notice of the emergency meeting will
+be
+given by email or by individual text message or
+phone call to all Members. d. The Notice of the emergency meeting shall include the decision item. e. Vote to Delay:
+The
+EAC may include with the Notice a binding vote with the Notice on whether the question of whether the item can or
+cannot
+wait until the next scheduled meeting time.
+i. If, at one hour before the emergency meeting, a majority of responses in the digital
+vote agrees that the meeting can wait, no meeting will take place. ii. If an emergency meeting does not take place,
+this
+item will be added to the next
+general meeting agenda. f. The agenda for an emergency meeting will be the emergency item only. g. An emergency
+meeting
+can take place at the regular meeting place of the Cooperative or by
+conference call. 7. Proposals: All Members shall be invited and welcomed to bring Proposals to the Cooperative. A
+Proposal includes, but is not limited to, any request to change Cooperative policy, procedures, or processes, to
+engage
+in a new project, or to change the roles and positions of Members. The EAC, in consultation with Members, will
+establish
+procedures for Members to bring a proposal to a vote. 8. Adopting Time Sensitive Proposals Outside of Meetings: In the
+event that an opportunity or need arises, and 60% of the Members agree that a Proposal needs to be considered quickly,
+then, if the Members are not in a meeting, the Members shall vote on a Proposal and the Proposal shall pass with the
+approval of 80% of the Members. The EAC shall keep a record of the proposal and outcome of the vote. If fewer than 60%
+of the Members agree that a decision is needed quickly, then the Proposal shall be made at the next Member Meeting and
+shall be brought and considered in the manner in which Proposals are required to be brought.
+6
+9. Quorum. The minimum number of Members needed to be at a meeting to make decisions binding is referred to as
+“quorum.”
+The Cooperative intends for its Members to initiate and lead projects for the Cooperative. It has therefore adopted a
+decision-making structure where most decisions can be made at a meeting with a smaller quorum while major decisions
+require a higher quorum.
+a. Default Provisions: Unless designated a Major Decision (as defined below), all proposals of the Cooperative may be
+considered and decided at a meeting with quorum of fifty percent (50%) of the Membership in attendance. b. Major
+decisions: The following proposals require a quorum of at least seventy percent
+(70%) of the Members in attendance:
+i. Getting a loan in amount of $50,000 or greater; ii. Changing the Cooperative’s primary business; iii. Merging,
+selling, or dissolving the Cooperative; iv. Amending this Agreement; and
+v. Entering the Cooperative into a financial obligation that exceeds $1,000. 10. Approving Proposals. Unless otherwise
+specified in this Agreement (including Section F.9 below) or as required by law, all proposals shall be approved by
+two-thirds (2/3rds) of the Members at a meeting with quorum.
+For illustration purposes only, here are some examples of quorum and approval requirements:
+Default Decision Major Decision
+Total Members 13 13
+
+Quorum required to hold a meeting 7
+(50% of 13, rounded up)
+11. Unanimous Consent Required:
+10 (70% of 13, rounded up)
+
+a. Amend this Operating Agreement. The unanimous consent of the Members is required to
+amend this Operating Agreement. b. Acts outside of the Ordinary Course of the Cooperative’s Activities. Pursuant to
+Section 17704.07(c)(4) of RULLCA (the California law governing LLCs), the unanimous approval of the Members is
+required
+to take any activities outside the ordinary course of the Cooperative’s activities, except as otherwise provided under
+Article 10 of RULLCA.
+
+Number of Votes to approve a proposal with a minimum Quorum in attendance*
+5 (2/3rds of 7)
+7 (2/3rds of 10, rounded up)
+7 (2/3rds of 10, rounded up)
+Number of Votes to approve a proposal with 11 Members in attendance*
+8 (2/3rds of 11)
+8 (2/3rds of 11)
+8 (2/3rds of 11)
+
+*Note: Quorum is calculated based on the total number of all Members. If greater than the minimum quorum actually
+attend
+a meeting, the votes required for approval are based on the actual number of Members in attendance, not the quorum
+number.
+7
+12. Committees and Delegation: The Members may delegate the management of certain tasks and realms to committees, and
+those committees shall meet separately from the Management Meetings. 13. Adopting Other Rules and Policies: The
+Members
+may adopt other rules and policies outside of this Agreement. The Members shall record all other rules and policies in
+a
+separate document that is provided to all Members, or they shall amend this Agreement to include the new rules and
+policies. E. Cooperative Projects
+1. Two Types of Cooperative Projects: The Cooperative will engage in two distinct types of projects
+and will record patronage for separately for each type, as follows:
+a. Direct Client Service Projects.
+i. Description: These projects shall typically be paid by a third-party client in
+exchange for services from the Cooperative and its agents. Direct Client Service Projects will typically have a
+defined
+scope, timeline, and negotiated rates with the third-party client. Contracts for Direct Client Service Projects shall
+typically be between the third-party client and the Cooperative. ii. Consolidated Patronage Record: The Cooperative
+shall maintain a consolidated record of all patronage by Members in support of all Direct Client Service Projects. b.
+Worker-Owned Technology Projects.
+i. Description. Members of the Cooperative may choose to develop software
+programs, applications, or other intellectual property for the purpose of commercialization, including but not limited
+to use in future Direct Client Service Projects. The Cooperative anticipates that Worker-Owned Technology Projects
+shall
+have a longer timeline for commercialization. ii. Distinct and Separate Patronage Records. The Cooperative seeks to
+simultaneously compensate those Members who contribute to the research and development of intellectual property while
+also maintaining flexibility for the Cooperative to determine the best means to commercialize any intellectual
+property.
+Therefore, for each Worker-Owned Technology Project, the Cooperative shall maintain a record of each Member’s
+patronage
+for each Worker-Owned Technology Project separately. We will keep written records of the date on which a product's
+development began and all Members and the Cooperative will track their work hours on each product. If certain work
+cannot be adequately pegged to a specific product, then the EAC, in consultation with the Members involved in the
+Worker-Owned Technology Project, will make reasonable estimates of time allocations across products and document the
+basis for the allocations. F. How Money is Managed in the Cooperative
+1. Capital Accounts.
+a. Each Member will have an internal account called the “Capital Account,” which generally represents an accounting of
+the Member’s contributions to and distributions from the Cooperative and the Member’s share of the Cooperative’s net
+profits and net losses. In particular, a Member’s Capital Account includes the total of the Member’s Capital
+Contributions in cash and the fair market value of any property contributed to the Cooperative (net of any liabilities
+that the Cooperative assumes) plus the Member’s share of Cooperative net profits, minus the amount of cash or the fair
+market value of any property
+8
+(net of any liabilities that the Member assumes) distributed to the Member from the Cooperative and minus the Member’s
+share of the Cooperative’s net losses. b. The Cooperative will maintain a separate Capital Account for each Member in
+accordance with the capital account rules of Section 1.704-1(b)(2)(iv) of the Treasury Regulations, and this Operating
+Agreement shall be interpreted and applied in a manner consistent with such Treasury Regulations. For this purpose,
+the
+Cooperative may, upon the occurrence of the events specified in Treasury Regulations Section 1.704-1(b)(2)(iv)(f),
+increase or decrease the Capital Accounts in accordance with the rules of such regulation and Treasury Regulations
+Section 1.704-1(b)(2)(iv)(g) to reflect a revaluation of Cooperative property. c. For purposes of this Agreement, “net
+profit” or “net loss” means the Cooperative’s taxable
+income or loss for federal income tax purposes for the applicable period, as reasonably adjusted by the EAC in
+consultation with a qualified accountant or bookkeeper. 2. Taxes.
+a. It is intended that the Cooperative be treated as a partnership for federal, state, and local
+income tax purposes. b. The Members shall, individually, be responsible for paying federal, state, and any local
+income taxes attributable to their share of the Cooperative’s net profits and losses, whether or not cash
+distributions
+are made by the Cooperative to the Members. c. Members understand that all Cooperative income must be allocated to the
+Members’ Capital
+Accounts, and acknowledge that they will need to pay taxes on the share of Cooperative income that is allocated to
+their
+Capital Accounts, including income that has not been distributed to Members. In addition, Members are responsible for
+paying all other taxes imposed on them individually, including quarterly self-employment taxes, as applicable. 3.
+Fiscal
+Year. The fiscal year of the Cooperative for accounting and tax purposes shall begin on
+January 1 and end on December 31, except for any shorter taxable years in the years of the Cooperative’s formation and
+termination. 4. Allocation of Profits. The net profits of the Cooperative shall be allocated among the Members
+based on i) the type of Project; and ii) the Member’s respective patronage for each project type, as follows:
+a. Direct Client Service Projects: Profits attributable to all Direct Client Service Projects shall be
+allocated to the Member’s based on the consolidated patronage account maintained in connection with these projects
+under
+Section E.1.a.ii above. b. Worker-Owned Technology Projects: The Members agree and acknowledge that profits are not
+anticipated on Worker-Owned Technology projects until the intellectual property can be successfully sold or licensed.
+When such profits are realized, they shall be divided among all past and present worker-owners on the basis of the
+total
+number of hours each worker- owner put into the product's development and marketing since the beginning of product
+development, consistent with the patronage records maintained for each project under Section E.1.b.ii. 5. Retaining
+Earnings and Making Distributions. Distributions are cash or other assets paid to
+Members from their Capital Accounts. On a quarterly basis, 30% of the Cooperative’s projected net profits attributable
+to the quarter in question, as reasonably determined by the EAC in consultation with a qualified accountant or
+bookkeeper, shall be distributed to the Members in the same manner that such net profits would be allocated to the
+Members pursuant to Section F.4. The Cooperative shall not make distributions to the Members if doing so would leave
+the
+Cooperative unable to pay its obligations and liabilities. A Member shall not be entitled to withdraw any part of the
+Member’s Capital Contribution or to receive any distributions, whether of money or property, from the Cooperative
+except
+as specifically provided in this Operating Agreement.
+9
+6. Sharing Losses. If the Cooperative has net losses, Members will share those net losses in proportion
+to their Capital Accounts. 7. Additional Tax Matters. Except as otherwise provided in this Operating Agreement, all
+items of Cooperative income, gain, loss, deduction and any other allocations not otherwise provided for shall be
+allocated among the Members in the same manner as net profits and net losses under Section F.4 and Section F.6, as the
+case may be. To the extent a Member shall have a negative Capital Account balance, there shall be a qualified income
+offset, as set forth in Section 1.704- 1(b)(2)(ii)(d) of the Treasury Regulations. Each item of income, gain, loss and
+deduction of the Cooperative for federal, state and local income tax purposes will be allocated among the Members in
+the
+same manner as such income, gain, loss or deduction is allocated among the Members’ Capital Accounts. Items of income,
+gain, loss and deduction of the Cooperative with respect to any property contributed to the capital of the Cooperative
+shall be allocated among the Members in accordance with Section 704(c) of the Internal Revenue Code of 1986, as
+amended
+(the “Code”), using any method allowed by Section 704(c) of the Code and the Treasury Regulations thereunder selected
+by
+the EAC. The Members shall make appropriate amendments to the allocations of items pursuant to this Section if
+necessary
+in order to comply with Section 704 of the Code and applicable Treasury Regulations. 8. Tax Return Information. Within
+90 days after the end of each taxable year, the Cooperative shall
+send to each Member:
+a. the information necessary to complete federal and state income tax or information returns;
+and b. a copy of the Cooperative’s federal, state, and local income tax or information returns for the
+year, if available, and if not as soon as it is available. 9. Tax Administration.
+a. The Members and the Cooperative acknowledge that the Cooperative is currently qualified
+under Section 6221(b) of the Code to elect out of the centralized partnership audit regime rules of Subchapter C of
+Chapter 63 of the Code, and hereby agree that the Cooperative shall make such election for all applicable tax years,
+in
+accordance with Section 6221(b) of the Code and applicable Treasury Regulations for so long as it qualifies. b. In the
+event the Cooperative is required to appoint a “Partnership Representative” within the
+meaning of Section 6223 of the Code (and any comparable provision of state or local law, including as “tax matters
+partner”) with respect to a tax year of the Cooperative, the Chair or the Treasurer of the EAC shall be the
+“Partnership
+Representative.” c. If applicable, the Partnership Representative:
+i. is authorized and required to represent the Cooperative (at the Cooperative’s expense) in connection with all
+income
+tax examinations of the Cooperative’s affairs by tax authorities; and ii. agrees not to settle or otherwise resolve
+any
+such examination in a manner
+that would materially and adversely affect the Members without the prior written consent of any such affected Members.
+d. If applicable, each Member agrees to cooperate with the Partnership Representative and the
+Cooperative with respect to the conduct of such examinations.
+G. Record Keeping and Accounting
+1. Member Information Statements: Each Member shall complete a Member Information Statement and provide it to the
+Administrator. It is the responsibility of the Member to provide a new
+10
+Statement to the Administrator any time the Member’s information changes. The Member Information Statement form is
+provided in Exhibit B. 2. Required Record Keeping: At all times, the Cooperative must maintain records of the
+following:
+a. Organizing and Governing Documents: An updated copy of the Cooperative’s current Operating Agreement, Articles of
+Organization, and any rules or policies adopted by the Member outside of this Agreement. b. Financial Information:
+Information regarding the financial condition of the Cooperative:
+i. Profit and loss statements, prepared on a quarterly basis; ii. Balance sheets, prepared on a quarterly basis; iii.
+Descriptions of the cash, bank account balances, and property of the Cooperative; iv. Patronage Records consistent
+with
+Sections E.1.a.ii and E.1.b.ii; and
+v. Any contributions that Members have been agreed to make in the future. c. Tax Returns: A copy of the federal,
+state,
+and local income taxes for each year, updated
+once available. d. Current Member Information Statements: Copies of all updated Member Information
+Statements. e. Past Member List: A list of all past Cooperative Members, including names, last known mailing address,
+phone number, email address, the Member’s designated beneficiary for payment of the Member’s Capital Account upon
+death
+and for dissolution distributions, dates of membership, and total number of hours worked during the membership. f.
+Meeting Records: A record of the minutes of Management Meeting proceedings. 3. Member Rights to Inspect Records: Each
+Member has the right to demand and receive, within a reasonable period of time, a copy of any of the above documents
+for
+any purpose reasonably related to their interest as a Member of the Cooperative. If a member would like a copy to
+keep,
+that Member shall pay for the copying expenses. The inspection may be made in person by the Member, or by an agent or
+attorney for the Member. 4. Annual Report: The Treasurer shall prepare, and all Members must receive, a copy of the
+annual report, prepared no later than 120 days after the end of the Cooperative’s fiscal year. The annual report must
+contain:
+a. A balance sheet; b. A detailed profit and loss statement for the full fiscal year; c. A statement of all debts of
+the
+Cooperative; d. A description of the basis on which each Member’s share of patronage or Loss was
+determined. H. How to Terminate Membership in The Cooperative
+1. Voluntary Resignation. A Member may withdraw from the Cooperative at any time upon written
+notice to the EAC. 2. Involuntary Termination: A Member is subject to withdrawal or expulsion from the Cooperative
+under the following circumstances:
+a. Death b. Performing no services for either a Direct Client Services Project or a Worker-Owned Technology Project
+for
+six (6) consecutive months unless that Member gives notice to the
+11
+EAC of an illness or disability that may prevent the Member from performing such services for no more than nine (9)
+months or under such other circumstances as are approved by the EAC; or c. Failure to achieve a Vote of Confidence. 3.
+Vote of Confidence: A Member may be expelled from the Cooperative based on a “Vote of Confidence” with respect to any
+Member’s status as a Member in the Cooperative if the Vote of Confidence is not approved.
+a. Violations that may trigger a Vote of Confidence include
+i. committing physical or verbal acts of violence against a Member or other persons
+related to the Cooperative; ii. using Cooperative resources or funds for personal benefit without the Members’
+approval; iii. Conviction of any felony; iv. Violating the terms of a client agreement, this Agreement, or the
+Cooperative’s
+Code of Conduct. b. A Vote of Confidence on a Member who committed a violation (the “Violating Member”) requires the
+affirmative vote of 80% of the membership for approval, not including the Violating Member. c. Where a Vote of
+Confidence regarding a Violating Member has failed, the membership of
+such Member shall be terminated. d. Upon notice of a violation that would trigger a Vote of Confidence, the EAC shall
+give notice to the Members of the reason(s) for the Vote of Confidence and no less than fourteen (14) days for the
+Members to submit their votes. Where a Member declines to submit a vote in response to such notice, it shall be
+considered a vote of no confidence. e. Specifically, the EAC shall send notice to the Members that includes at minimum
+the
+following information:
+i. name of the Member subject to a Vote of Confidence ii. a brief description of the triggering event prepared by the
+EAC; iii. A statement from the Member, if desired, disputing the triggering event iv. At the EAC’s option, a response
+from the EAC to the Member’s dispute of the
+triggering event. 4. Rights upon Termination.
+a. No Further Activities. Termination of membership automatically removes an individual from all positions in the
+Cooperative, including but not limited to any committee of the Cooperative. b. No Waiver of Liabilities. A Member
+whose
+membership in the Cooperative is terminated
+shall be liable for any charges, dues, or other obligations incurred before the termination. c. Conversion of
+Membership
+to Loan. When a Member ends her membership voluntarily or involuntarily (except in the case of death, see below), that
+Member’s Capital Account and other debts the Cooperative owes the Member become a loan to the Cooperative. That loan
+must be paid to the Member within five years. The loan shall not accumulate interest during the first year. After the
+first year, it will accumulate interest at an APR of 3% on the outstanding amount. If funds are available and, with
+approval by at least 75% of the Members, the Cooperative may elect to pay the Member within 30 days of when she
+leaves.
+There shall be no fee or penalty for prepayment of such loan by the Cooperative. d. Designated Beneficiary in case of
+Death. If a Member passes away, the payment will go to the Member’s Designated Beneficiary(ies), whose name appears in
+the Statement of Information of that Member. If a Member has passed away and has not named a
+12
+Designated Beneficiary, or if the Cooperative cannot find the ex‐Member or Designated Beneficiary after reasonable
+effort, the Cooperative will not be obliged to distribute to that Member, her Designated Beneficiary, or any other
+heir
+or beneficiary of that Member. I. How to Resolve Conflicts
+1. When a conflict arises between Members or between a Member and the Cooperative that cannot be resolved through good
+faith discussion, either party may elect to submit to binding arbitration. The venue for arbitration shall be agreed
+to
+by the parties to the arbitration, or if the parties cannot agree, at a venue selected by the EAC. 2. All arbitration
+decisions shall be final, binding and conclusive on all the parties to arbitration, and legal judgment may be entered
+based upon such decision in accordance with applicable law in any court having jurisdiction to do so. 3. The opposing
+parties shall agree to each pay half the cost of binding arbitration procedures. J. Additional Provisions
+1. Complete Agreement: This Agreement and the Articles of Organization constitute the complete and exclusive statement
+of the Members with respect to the subject matter herein and therein and replace and supersede all prior written and
+oral agreements or statements by the Members. If there is any conflict between the provisions of this Agreement and
+the
+Articles of Organization, then the provisions of this Agreement, to the extent permitted under California law, shall
+control. 2. Mandatory Review of Operating Agreement: Upon the occurrence of any of the following events, the
+Cooperative
+will appoint a committee to review and recommend to the Cooperative amendments to this Agreement. The committee must
+deliver its recommendations at a Monthly Member Meeting no less than six (6) months after the occurrence of the
+triggering event.
+a. A change in the Approved Purpose of the Cooperative. b. When the total number of Members reaches twelve (12). c.
+When
+total revenues from Worker-Owned Technology Projects exceeds $100,000. 3. If a Member is Sued by Someone Outside of
+the
+Cooperative: All Members will be indemnified and held harmless by the Cooperative from and against any and all claims
+of
+any nature arising out of a Member's participation in Cooperative affairs. A Member will not be entitled to
+indemnification under this section for liability arising out of gross negligence or willful misconduct of the Member
+or
+the breach by the Member of any provisions of this Agreement. This means, for example, that the Cooperative will
+compensate and help to defend a Member who is sued for damages that occur when the Member is working for the
+Cooperative. 4. Members Will Not Be Liable for Good Faith Mistakes: If a Member is acting in good faith and in service
+of the Cooperative, and if she makes a mistake or error in judgment, or commits an unintentional act or omission, the
+Member will not be liable to the Cooperative or to any other Member for the mistake or error. The Member will be
+liable
+only for acts and omissions involving intentional wrongdoing. 5. Gender Pronouns: Even though we typically use “she”
+and
+“her” throughout this Agreement, these
+words should be interpreted to mean “he, she, or they” or “his, her, or their.”
+13
+6. The Bold Headings Are Not a Legally Binding Part of This Agreement: We have included very descriptive headings in
+this Agreement, in order to make it easy to read and navigate. However, these bold headings shall not be considered to
+be a legally binding part of this Agreement. 7. How to Provide Notice to Members: Any time that a Member or the
+Cooperative is required to give notice to the Members, the notice shall be given by any of the following methods: 1)
+Notice may be mailed to the physical addresses of the Members, in which case notice shall be considered given three
+business days after place the notice in the mail with first class postage; 2) Notice may be delivered by email or text
+to the email addresses and phone numbers provided by Members, in which case notice shall be considered delivered when
+the member replies to the email and acknowledges receipt; 3) Notice may be delivered in person, in which case notice
+shall be considered delivered when the notice is placed in the hands of the Member, and 4) Notice may be delivered by
+telephone, in which case notice shall be considered delivered when the receiving Member voices acknowledgment of the
+notice. 8. Severability: If any provision of this Agreement is held by a court to be invalid or unenforceable, Members
+agree that the provision shall be reduced in scope by the court only to the extent deemed necessary by that court to
+render the provision reasonable and enforceable, and the remaining provisions of this Agreement will not be affected
+or
+invalidated as a result. 9. This Agreement is Binding on Successors: This Agreement and the terms and conditions
+contained in this Agreement apply to and are binding upon the Member's successors, assigns, executors, administrators,
+beneficiaries, and representatives.
+14
+the Members hereby agree to all of the terms and conditions in this Agreement.
+
+<footer>
+  <a href="https://drive.google.com/file/d/1f45o0cz769fpJDSrypvk579CL5Iwi8St/view?usp=sharing">PDF</a>
+</footer>

--- a/src/operating-agreement/index.html
+++ b/src/operating-agreement/index.html
@@ -359,26 +359,43 @@
       include the new rules and policies.</p>
   </section>
 </section>
+<section id="e-cooperative-projects">
+  <h2>E. Cooperative Projects</h2>
+  <section id="e-1-two-types-of-projects">
+    <h3>1. Two Types of Cooperative Projects</h3>
+    <p>The Cooperative will engage in two distinct types of projects and will record patronage for separately for each
+      type, as follows:</p>
+    <section id="e-1-a-direct-client-service-projects">
+      <h4>a. Direct Client Service Projects.</h4>
+      <p id="e-1-a-i-description"> i. Description: These projects shall typically be paid by a third-party client in
+        exchange for services from the Cooperative and its agents. Direct Client Service Projects will typically have
+        a defined scope, timeline, and negotiated rates with the third-party client. Contracts for Direct Client
+        Service Projects shall typically be between the third-party client and the Cooperative. </p>
+      <p id="e-1-a-ii-consolidated-patronage-records"> ii. Consolidated Patronage Record: The Cooperative shall
+        maintain a consolidated record of all patronage by Members in support of all Direct Client Service Projects.
+      </p>
+    </section>
+    <section id="e-1-b-worker-owned-technology-projects">
+      <h4>b. Worker-Owned Technology Projects.</h4>
+      <p id="e-1-b-i-description">i. Description. Members of the Cooperative may choose to develop software programs,
+        applications, or other intellectual property for the purpose of commercialization, including but not limited
+        to use in future Direct Client Service Projects. The Cooperative anticipates that Worker-Owned Technology
+        Projects shall have a longer timeline for commercialization.</p>
+      <p id="e-1-b-ii-distinct-and-separate-patronage-records"> ii. Distinct and Separate Patronage Records. The
+        Cooperative seeks to simultaneously compensate those Members who contribute to the research and development of
+        intellectual property while also maintaining flexibility for the Cooperative to determine the best means to
+        commercialize any intellectual property. Therefore, for each Worker-Owned Technology Project, the Cooperative
+        shall maintain a record of each Member’s patronage for each Worker-Owned Technology Project separately. We
+        will keep written records of the date on which a product's development began and all Members and the
+        Cooperative will track their work hours on each product. If certain work cannot be adequately pegged to a
+        specific product, then the EAC, in consultation with the Members involved in the Worker-Owned Technology
+        Project, will make reasonable estimates of time allocations across products and document the basis for the
+        allocations.</p>
+    </section>
+  </section>
+</section>
 <pre>
-    E. Cooperative Projects 1. Two Types of Cooperative Projects: The Cooperative will engage in
-  two distinct types of projects and will record patronage for separately for each type, as follows: a. Direct Client
-  Service Projects. i. Description: These projects shall typically be paid by a third-party client in exchange for
-  services from the Cooperative and its agents. Direct Client Service Projects will typically have a defined scope,
-  timeline, and negotiated rates with the third-party client. Contracts for Direct Client Service Projects shall typically
-  be between the third-party client and the Cooperative. ii. Consolidated Patronage Record: The Cooperative shall maintain
-  a consolidated record of all patronage by Members in support of all Direct Client Service Projects. b. Worker-Owned
-  Technology Projects. i. Description. Members of the Cooperative may choose to develop software programs, applications,
-  or other intellectual property for the purpose of commercialization, including but not limited to use in future Direct
-  Client Service Projects. The Cooperative anticipates that Worker-Owned Technology Projects shall have a longer timeline
-  for commercialization. ii. Distinct and Separate Patronage Records. The Cooperative seeks to simultaneously compensate
-  those Members who contribute to the research and development of intellectual property while also maintaining flexibility
-  for the Cooperative to determine the best means to commercialize any intellectual property. Therefore, for each
-  Worker-Owned Technology Project, the Cooperative shall maintain a record of each Member’s patronage for each
-  Worker-Owned Technology Project separately. We will keep written records of the date on which a product's development
-  began and all Members and the Cooperative will track their work hours on each product. If certain work cannot be
-  adequately pegged to a specific product, then the EAC, in consultation with the Members involved in the Worker-Owned
-  Technology Project, will make reasonable estimates of time allocations across products and document the basis for the
-  allocations. F. How Money is Managed in the Cooperative 1. Capital Accounts. a. Each Member will have an internal
+  F. How Money is Managed in the Cooperative 1. Capital Accounts. a. Each Member will have an internal
   account called the “Capital Account,” which generally represents an accounting of the Member’s contributions to and
   distributions from the Cooperative and the Member’s share of the Cooperative’s net profits and net losses. In
   particular, a Member’s Capital Account includes the total of the Member’s Capital Contributions in cash and the fair

--- a/src/operating-agreement/index.html
+++ b/src/operating-agreement/index.html
@@ -513,107 +513,228 @@
       with the Partnership Representative and the Cooperative with respect to the conduct of such examinations.</p>
   </section>
 </section>
-<pre>
-  G. Record Keeping and Accounting 1. Member Information
-  Statements: Each Member shall complete a Member Information Statement and provide it to the Administrator. It is the
-  responsibility of the Member to provide a new 10 Statement to the Administrator any time the Member’s information
-  changes. The Member Information Statement form is provided in Exhibit B. 2. Required Record Keeping: At all times, the
-  Cooperative must maintain records of the following: a. Organizing and Governing Documents: An updated copy of the
-  Cooperative’s current Operating Agreement, Articles of Organization, and any rules or policies adopted by the Member
-  outside of this Agreement. b. Financial Information: Information regarding the financial condition of the Cooperative:
-  i. Profit and loss statements, prepared on a quarterly basis; ii. Balance sheets, prepared on a quarterly basis; iii.
-  Descriptions of the cash, bank account balances, and property of the Cooperative; iv. Patronage Records consistent with
-  Sections E.1.a.ii and E.1.b.ii; and v. Any contributions that Members have been agreed to make in the future. c. Tax
-  Returns: A copy of the federal, state, and local income taxes for each year, updated once available. d. Current Member
-  Information Statements: Copies of all updated Member Information Statements. e. Past Member List: A list of all past
-  Cooperative Members, including names, last known mailing address, phone number, email address, the Member’s designated
-  beneficiary for payment of the Member’s Capital Account upon death and for dissolution distributions, dates of
-  membership, and total number of hours worked during the membership. f. Meeting Records: A record of the minutes of
-  Management Meeting proceedings. 3. Member Rights to Inspect Records: Each Member has the right to demand and receive,
-  within a reasonable period of time, a copy of any of the above documents for any purpose reasonably related to their
-  interest as a Member of the Cooperative. If a member would like a copy to keep, that Member shall pay for the copying
-  expenses. The inspection may be made in person by the Member, or by an agent or attorney for the Member. 4. Annual
-  Report: The Treasurer shall prepare, and all Members must receive, a copy of the annual report, prepared no later than
-  120 days after the end of the Cooperative’s fiscal year. The annual report must contain: a. A balance sheet; b. A
-  detailed profit and loss statement for the full fiscal year; c. A statement of all debts of the Cooperative; d. A
-  description of the basis on which each Member’s share of patronage or Loss was determined. H. How to Terminate
-  Membership in The Cooperative 1. Voluntary Resignation. A Member may withdraw from the Cooperative at any time upon
-  written notice to the EAC. 2. Involuntary Termination: A Member is subject to withdrawal or expulsion from the
-  Cooperative under the following circumstances: a. Death b. Performing no services for either a Direct Client Services
-  Project or a Worker-Owned Technology Project for six (6) consecutive months unless that Member gives notice to the 11
-  EAC of an illness or disability that may prevent the Member from performing such services for no more than nine (9)
-  months or under such other circumstances as are approved by the EAC; or c. Failure to achieve a Vote of Confidence. 3.
-  Vote of Confidence: A Member may be expelled from the Cooperative based on a “Vote of Confidence” with respect to any
-  Member’s status as a Member in the Cooperative if the Vote of Confidence is not approved. a. Violations that may trigger
-  a Vote of Confidence include i. committing physical or verbal acts of violence against a Member or other persons related
-  to the Cooperative; ii. using Cooperative resources or funds for personal benefit without the Members’ approval; iii.
-  Conviction of any felony; iv. Violating the terms of a client agreement, this Agreement, or the Cooperative’s Code of
-  Conduct. b. A Vote of Confidence on a Member who committed a violation (the “Violating Member”) requires the affirmative
-  vote of 80% of the membership for approval, not including the Violating Member. c. Where a Vote of Confidence regarding
-  a Violating Member has failed, the membership of such Member shall be terminated. d. Upon notice of a violation that
-  would trigger a Vote of Confidence, the EAC shall give notice to the Members of the reason(s) for the Vote of Confidence
-  and no less than fourteen (14) days for the Members to submit their votes. Where a Member declines to submit a vote in
-  response to such notice, it shall be considered a vote of no confidence. e. Specifically, the EAC shall send notice to
-  the Members that includes at minimum the following information: i. name of the Member subject to a Vote of Confidence
-  ii. a brief description of the triggering event prepared by the EAC; iii. A statement from the Member, if desired,
-  disputing the triggering event iv. At the EAC’s option, a response from the EAC to the Member’s dispute of the
-  triggering event. 4. Rights upon Termination. a. No Further Activities. Termination of membership automatically removes
-  an individual from all positions in the Cooperative, including but not limited to any committee of the Cooperative. b.
-  No Waiver of Liabilities. A Member whose membership in the Cooperative is terminated shall be liable for any charges,
-  dues, or other obligations incurred before the termination. c. Conversion of Membership to Loan. When a Member ends her
-  membership voluntarily or involuntarily (except in the case of death, see below), that Member’s Capital Account and
-  other debts the Cooperative owes the Member become a loan to the Cooperative. That loan must be paid to the Member
-  within five years. The loan shall not accumulate interest during the first year. After the first year, it will
-  accumulate interest at an APR of 3% on the outstanding amount. If funds are available and, with approval by at least 75%
-  of the Members, the Cooperative may elect to pay the Member within 30 days of when she leaves. There shall be no fee or
-  penalty for prepayment of such loan by the Cooperative. d. Designated Beneficiary in case of Death. If a Member passes
-  away, the payment will go to the Member’s Designated Beneficiary(ies), whose name appears in the Statement of
-  Information of that Member. If a Member has passed away and has not named a 12 Designated Beneficiary, or if the
-  Cooperative cannot find the ex‐Member or Designated Beneficiary after reasonable effort, the Cooperative will not be
-  obliged to distribute to that Member, her Designated Beneficiary, or any other heir or beneficiary of that Member. I.
-  How to Resolve Conflicts 1. When a conflict arises between Members or between a Member and the Cooperative that cannot
-  be resolved through good faith discussion, either party may elect to submit to binding arbitration. The venue for
-  arbitration shall be agreed to by the parties to the arbitration, or if the parties cannot agree, at a venue selected by
-  the EAC. 2. All arbitration decisions shall be final, binding and conclusive on all the parties to arbitration, and
-  legal judgment may be entered based upon such decision in accordance with applicable law in any court having
-  jurisdiction to do so. 3. The opposing parties shall agree to each pay half the cost of binding arbitration procedures.
-  J. Additional Provisions 1. Complete Agreement: This Agreement and the Articles of Organization constitute the complete
-  and exclusive statement of the Members with respect to the subject matter herein and therein and replace and supersede
-  all prior written and oral agreements or statements by the Members. If there is any conflict between the provisions of
-  this Agreement and the Articles of Organization, then the provisions of this Agreement, to the extent permitted under
-  California law, shall control. 2. Mandatory Review of Operating Agreement: Upon the occurrence of any of the following
-  events, the Cooperative will appoint a committee to review and recommend to the Cooperative amendments to this
-  Agreement. The committee must deliver its recommendations at a Monthly Member Meeting no less than six (6) months after
-  the occurrence of the triggering event. a. A change in the Approved Purpose of the Cooperative. b. When the total number
-  of Members reaches twelve (12). c. When total revenues from Worker-Owned Technology Projects exceeds $100,000. 3. If a
-  Member is Sued by Someone Outside of the Cooperative: All Members will be indemnified and held harmless by the
-  Cooperative from and against any and all claims of any nature arising out of a Member's participation in Cooperative
-  affairs. A Member will not be entitled to indemnification under this section for liability arising out of gross
-  negligence or willful misconduct of the Member or the breach by the Member of any provisions of this Agreement. This
-  means, for example, that the Cooperative will compensate and help to defend a Member who is sued for damages that occur
-  when the Member is working for the Cooperative. 4. Members Will Not Be Liable for Good Faith Mistakes: If a Member is
-  acting in good faith and in service of the Cooperative, and if she makes a mistake or error in judgment, or commits an
-  unintentional act or omission, the Member will not be liable to the Cooperative or to any other Member for the mistake
-  or error. The Member will be liable only for acts and omissions involving intentional wrongdoing. 5. Gender Pronouns:
-  Even though we typically use “she” and “her” throughout this Agreement, these words should be interpreted to mean “he,
-  she, or they” or “his, her, or their.” 13 6. The Bold Headings Are Not a Legally Binding Part of This Agreement: We have
-  included very descriptive headings in this Agreement, in order to make it easy to read and navigate. However, these bold
-  headings shall not be considered to be a legally binding part of this Agreement. 7. How to Provide Notice to Members:
-  Any time that a Member or the Cooperative is required to give notice to the Members, the notice shall be given by any of
-  the following methods: 1) Notice may be mailed to the physical addresses of the Members, in which case notice shall be
-  considered given three business days after place the notice in the mail with first class postage; 2) Notice may be
-  delivered by email or text to the email addresses and phone numbers provided by Members, in which case notice shall be
-  considered delivered when the member replies to the email and acknowledges receipt; 3) Notice may be delivered in
-  person, in which case notice shall be considered delivered when the notice is placed in the hands of the Member, and 4)
-  Notice may be delivered by telephone, in which case notice shall be considered delivered when the receiving Member
-  voices acknowledgment of the notice. 8. Severability: If any provision of this Agreement is held by a court to be
-  invalid or unenforceable, Members agree that the provision shall be reduced in scope by the court only to the extent
-  deemed necessary by that court to render the provision reasonable and enforceable, and the remaining provisions of this
-  Agreement will not be affected or invalidated as a result. 9. This Agreement is Binding on Successors: This Agreement
-  and the terms and conditions contained in this Agreement apply to and are binding upon the Member's successors, assigns,
-  executors, administrators, beneficiaries, and representatives. the Members hereby agree to all of the terms and
-  conditions in this Agreement.
-</pre>
+<section id="g-record-keeping-and-accounting">
+  <h2>G. Record Keeping and Accounting</h2>
+  <section id="g-1-member-information-statements">
+    <h3>1. Member Information Statements</h3>
+    <p>Each Member shall complete a Member Information Statement and provide it to the Administrator. It is the
+      responsibility of the Member to provide a new 10 Statement to the Administrator any time the Member’s information
+      changes. The Member Information Statement form is provided in Exhibit B.</p>
+  </section>
+  <section id="g-2-required-record-keeping">
+    <h3>2. Required Record Keeping</h3>
+    <p>At all times, the Cooperative must maintain records of the following:</p>
+    <section id="g-2-a-organizing-and-governing-documents">
+      <h4>a. Organizing and Governing Documents</h4>
+      <p>An updated copy of the Cooperative’s current Operating Agreement, Articles of Organization, and any rules or
+        policies adopted by the Member outside of this Agreement.</p>
+    </section>
+    <section id="g-2-b-financial-information">
+      <h3>b. Financial Information</h3>
+      <p>Information regarding the financial condition of the Cooperative:</p>
+      <p id="g-2-b-i-quarterly-profit-and-loss-statements">i. Profit and loss statements, prepared on a quarterly basis;
+      </p>
+      <p id="g-2-b-ii-quarterly-balance-sheets">ii. Balance sheets, prepared on a quarterly basis;</p>
+      <p id="g-2-b-iii-descriptions-of-cash-accounts-and-property">iii. Descriptions of the cash, bank account balances,
+        and property of the Cooperative;</p>
+      <p id="g-2-b-iv-patronage-records">iv. Patronage Records consistent with Sections E.1.a.ii and E.1.b.ii; and</p>
+      <p id="g-2-b-v-future-contribution">v. Any contributions that Members have been agreed to make in the future.</p>
+    </section>
+    <section id="g-2-c-tax-returns">
+      <h3>c. Tax Returns</h3>
+      <p>A copy of the federal, state, and local income taxes for each year, updated once available.</p>
+    </section>
+    <section id="g-2-d-current-member-information-statements">
+      <h3>d. Current Member Information Statements</h3>
+      <p>Copies of all updated Member Information Statements.</p>
+    </section>
+    <section id="g-2-e-past-member-list">
+      <h3>e. Past Member List</h3>
+      <p>A list of all past Cooperative Members, including names, last known mailing address, phone number, email
+        address, the Member’s designated beneficiary for payment of the Member’s Capital Account upon death and for
+        dissolution distributions, dates of membership, and total number of hours worked during the membership.</p>
+    </section>
+    <section id="g-2-f-meeting-records">
+      <h3>f. Meeting Records</h3>
+      <p>A record of the minutes of Management Meeting proceedings.</p>
+    </section>
+  </section>
+  <section id="g-3-member-rights-to-inspect-records">
+    <h3>3. Member Rights to Inspect Records</h3>
+    <p>Each Member has the right to demand and receive, within a reasonable period of time, a copy of any of the above
+      documents for any purpose reasonably related to their interest as a Member of the Cooperative. If a member would
+      like a copy to keep, that Member shall pay for the copying expenses. The inspection may be made in person by the
+      Member, or by an agent or attorney for the Member.</p>
+  </section>
+  <section id="g-4-annual-report">
+    <h3>4. Annual Report</h3>
+    <p>The Treasurer shall prepare, and all Members must receive, a copy of the annual report, prepared no later than
+      120 days after the end of the Cooperative’s fiscal year. The annual report must contain:</p>
+    <p id="g-4-a-balance-sheet">a. A balance sheet;</p>
+    <p id="g-4-b-profit-and-loss-statement">b. A detailed profit and loss statement for the full fiscal year;</p>
+    <p id="g-4-c-statement-of-debts">c. A statement of all debts of the Cooperative;</p>
+    <p id="g-4-d-description-of-patronae-basis">d. A description of the basis on which each Member’s share of patronage
+      or Loss was determined.</p>
+  </section>
+</section>
+<section id="h-termination-of-membership">
+  <h2> H. How to Terminate Membership in The Cooperative</h2>
+  <section id="h-1-voluntary-resignation">
+    <h3>1. Voluntary Resignation.</h3>
+    <p>A Member may withdraw from the Cooperative at any time upon written notice to the EAC.</p>
+  </section>
+  <section id="h-2-involuntary-termination">
+    <h3>2. Involuntary Termination</h3>
+    <p>A Member is subject to withdrawal or expulsion from the Cooperative under the following circumstances:</p>
+    <p id="h-2-a-death">a. Death</p>
+    <p id="h-2-b-performing-no-services">b. Performing no services for either a Direct Client Services Project or a
+      Worker-Owned Technology Project for six (6) consecutive months unless that Member gives notice to the 11 EAC of an
+      illness or disability that may prevent the Member from performing such services for no more than nine (9) months
+      or under such other circumstances as are approved by the EAC; or</p>
+    <p id="h-2-c-vote-of-confidence">c. Failure to achieve a Vote of Confidence.</p>
+  </section>
+  <section id="h-3-vote-of-confidence">
+    <h3>3. Vote of Confidence</h3>
+    <p>A Member may be expelled from the Cooperative based on a “Vote of Confidence” with respect to any Member’s status
+      as a Member in the Cooperative if the Vote of Confidence is not approved.</p>
+    <section id="h-3-a-triggers-and-violations">
+      <p>a. Violations that may trigger a Vote of Confidence include</p>
+      <p id="h-3-a-i-acts-of-violence">i. committing physical or verbal acts of violence against a Member or other
+        persons related to the Cooperative;</p>
+      <p id="h-3-a-ii-personal-benefit-without-approval">ii. using Cooperative resources or funds for personal benefit
+        without the Members’ approval;</p>
+      <p id="h-3-a-iii-conviction-of-felony">iii. Conviction of any felony;</p>
+      <p id="h-3-a-iv-violation-of-conduct">iv. Violating the terms of a client agreement, this Agreement, or the
+        Cooperative’s Code of Conduct.</p>
+    </section>
+    <p id="h-3-b-affirmative-vote">b. A Vote of Confidence on a Member who committed a violation (the “Violating
+      Member”) requires the affirmative vote of 80% of the membership for approval, not including the Violating Member.
+    </p>
+    <p id="h-3-c-upon-failure">c. Where a Vote of Confidence regarding a Violating Member has failed, the membership of
+      such Member shall be terminated.</p>
+    <p id="h-3-d-timing-of-notice"> d. Upon notice of a violation that would trigger a Vote of Confidence, the EAC shall
+      give notice to the Members of the reason(s) for the Vote of Confidence and no less than fourteen (14) days for the
+      Members to submit their votes. Where a Member declines to submit a vote in response to such notice, it shall be
+      considered a vote of no confidence.</p>
+    <p id="h-3-e-content-of-notice"> e. Specifically, the EAC shall send notice to the Members that includes at minimum
+      the following information:</p>
+    <p id="h-3-e-i-name-of-member">i. name of the Member subject to a Vote of Confidence</p>
+    <p id="h-3-e-ii-brief-of-triggering-event">ii. a brief description of the triggering event prepared by the EAC;</p>
+    <p id="h-3-e-iii-optional-statement-from-member">iii. A statement from the Member, if desired, disputing the
+      triggering event</p>
+    <p id="h-3-e-iv-optional-response-from-eac">iv. At the EAC’s option, a response from the EAC to the Member’s dispute
+      of the triggering event.</p>
+  </section>
+  <section id="h-4-rights-upon-termination">
+    <h3>4. Rights upon Termination.</h3>
+    <section id="h-4-a-no-further-activities">
+      <h4>a. No Further Activities.</h4>
+      <p>Termination of membership automatically removes an individual from all positions in the Cooperative, including
+        but not limited to any committee of the Cooperative.</p>
+    </section>
+    <section id="h-4-b-no-waiver-of-liabilities">
+      <h4>b. No Waiver of Liabilities.</h4>
+      <p> A Member whose membership in the Cooperative is terminated shall be liable for any charges, dues, or other
+        obligations incurred before the termination.</p>
+    </section>
+    <section id="h-4-c-membership-conversion-to-loan">
+      <h4>c. Conversion of Membership to Loan.</h4>
+      <p>When a Member ends her membership voluntarily or involuntarily (except in the case of death, see below), that
+        Member’s Capital Account and other debts the Cooperative owes the Member become a loan to the Cooperative. That
+        loan must be paid to the Member within five years. The loan shall not accumulate interest during the first year.
+        After the first year, it will accumulate interest at an APR of 3% on the outstanding amount. If funds are
+        available and, with approval by at least 75% of the Members, the Cooperative may elect to pay the Member within
+        30 days of when she leaves. There shall be no fee or penalty for prepayment of such loan by the Cooperative. d.
+        Designated Beneficiary in case of Death. If a Member passes away, the payment will go to the Member’s Designated
+        Beneficiary(ies), whose name appears in the Statement of Information of that Member. If a Member has passed away
+        and has not named a 12 Designated Beneficiary, or if the Cooperative cannot find the ex‐Member or Designated
+        Beneficiary after reasonable effort, the Cooperative will not be obliged to distribute to that Member, her
+        Designated Beneficiary, or any other heir or beneficiary of that Member.</p>
+    </section>
+  </section>
+</section>
+<section id="i-conflict-resolution">
+  <h2>I. How to Resolve Conflicts</h2>
+  <p id="i-1-election-of-arbitration"> 1. When a conflict arises between Members or between a Member and the Cooperative
+    that cannot be resolved through good faith discussion, either party may elect to submit to binding arbitration. The
+    venue for arbitration shall be agreed to by the parties to the arbitration, or if the parties cannot agree, at a
+    venue selected by the EAC. </p>
+  <p id="i-2-finality-of-decisions">2. All arbitration decisions shall be final, binding and conclusive on all the
+    parties to arbitration, and legal judgment may be entered based upon such decision in accordance with applicable law
+    in any court having jurisdiction to do so.</p>
+  <p id="i-3-costs-of-arbitration"> 3. The opposing parties shall agree to each pay half the cost of binding arbitration
+    procedures. </p>
+</section>
+<section id="j-additional-provisions">
+  <h2>J. Additional Provisions</h2>
+  <section id="j-1-complete-agreement">
+    <h3>1. Complete Agreement</h3>
+    <p>This Agreement and the Articles of Organization constitute the complete and exclusive statement of the Members
+      with respect to the subject matter herein and therein and replace and supersede all prior written and oral
+      agreements or statements by the Members. If there is any conflict between the provisions of this Agreement and the
+      Articles of Organization, then the provisions of this Agreement, to the extent permitted under California law,
+      shall control.</p>
+  </section>
+  <section id="j-2-mandatory-review-of-agreement">
+    <h3>2. Mandatory Review of Operating Agreement</h3>
+    <p>Upon the occurrence of any of the following events, the Cooperative will appoint a committee to review and
+      recommend to the Cooperative amendments to this Agreement. The committee must deliver its recommendations at a
+      Monthly Member Meeting no less than six (6) months after the occurrence of the triggering event.</p>
+    <p id="j-2-a-trigger-via-changed-purpose">a. A change in the Approved Purpose of the Cooperative. </p>
+    <p id="j-2-b-trigger-via-member-growth">b. When the total number of Members reaches twelve (12).</p>
+    <p id="j-2-c-trigger-via-revenue">c. When total revenues from Worker-Owned Technology Projects exceeds $100,000.</p>
+  </section>
+  <section id="j-3-member-indemnification">
+    <h3>3. If a Member is Sued by Someone Outside of the Cooperative</h3>
+    <p>All Members will be indemnified and held harmless by the Cooperative from and against any and all claims of any
+      nature arising out of a Member's participation in Cooperative affairs. A Member will not be entitled to
+      indemnification under this section for liability arising out of gross negligence or willful misconduct of the
+      Member or the breach by the Member of any provisions of this Agreement. This means, for example, that the
+      Cooperative will compensate and help to defend a Member who is sued for damages that occur when the Member is
+      working for the Cooperative.</p>
+  </section>
+  <section id="j-4-member-liability-for-good-faith-mistakes">
+    <h3>4. Members Will Not Be Liable for Good Faith Mistakes</h3>
+    <p>If a Member is acting in good faith and in service of the Cooperative, and if she makes a mistake or error in
+      judgment, or commits an unintentional act or omission, the Member will not be liable to the Cooperative or to any
+      other Member for the mistake or error. The Member will be liable only for acts and omissions involving intentional
+      wrongdoing.</p>
+  </section>
+  <section id="j-5-gender-pronouns">
+    <h3>5. Gender Pronouns</h3>
+    <p> Even though we typically use “she” and “her” throughout this Agreement, these words should be interpreted to
+      mean “he, she, or they” or “his, her, or their.”</p>
+  </section>
+  <section id="j-6-non-binding-bold-headings">
+    <h3>6. The Bold Headings Are Not a Legally Binding Part of This Agreement</h3>
+    <p>We have included very descriptive headings in this Agreement, in order to make it easy to read and navigate.
+      However, these bold headings shall not be considered to be a legally binding part of this Agreement.</p>
+  </section>
+  <section id="j-7-providing-notice">
+    <h3>7. How to Provide Notice to Members</h3>
+    <p> Any time that a Member or the Cooperative is required to give notice to the Members, the notice shall be given
+      by any of the following methods: 1) Notice may be mailed to the physical addresses of the Members, in which case
+      notice shall be considered given three business days after place the notice in the mail with first class postage;
+      2) Notice may be delivered by email or text to the email addresses and phone numbers provided by Members, in which
+      case notice shall be considered delivered when the member replies to the email and acknowledges receipt; 3) Notice
+      may be delivered in person, in which case notice shall be considered delivered when the notice is placed in the
+      hands of the Member, and 4) Notice may be delivered by telephone, in which case notice shall be considered
+      delivered when the receiving Member voices acknowledgment of the notice.</p>
+  </section>
+  <section id="j-8-severability">
+    <h3>8. Severability</h3>
+    <p>If any provision of this Agreement is held by a court to be invalid or unenforceable, Members agree that the
+      provision shall be reduced in scope by the court only to the extent deemed necessary by that court to render the
+      provision reasonable and enforceable, and the remaining provisions of this Agreement will not be affected or
+      invalidated as a result.</p>
+  </section>
+  <section id="j-9-binding-on-successors">
+    <h3>9. This Agreement is Binding on Successors</h3>
+    <p>This Agreement and the terms and conditions contained in this Agreement apply to and are binding upon the
+      Member's successors, assigns, executors, administrators, beneficiaries, and representatives. the Members hereby
+      agree to all of the terms and conditions in this Agreement.</p>
+  </section>
+</section>
 <footer>
   <a href="https://drive.google.com/file/d/1f45o0cz769fpJDSrypvk579CL5Iwi8St/view?usp=sharing">PDF</a>
 </footer>


### PR DESCRIPTION
Before diving into turning this into a web site builder, I wanted to
take a moment to read through it and format it as plain HTML with ID's
for deep-linking for two reasons:

1. It re-familiarizes me with all the details; so I can better comply
   with the agreements we've made _and_
2. It gives me a chance to think about the things I may want to work on
   for a v1.1 of the agreement (for instance, including a
   consumer-owner component, or adding explicit seams for modularity if
   others want to use it for their cooperative)

Unfortunately, I ran out of time for today. If someone else carries it
forward I wouldn't be sad.
