### PR TITLE
Fix pdf and CNAME file passthru

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,8 @@ module.exports = function(config) {
 
   // Layout aliases can make templates more portable
   config.addLayoutAlias('default', 'layouts/default.njk');
-  config.addPassthroughCopy("*.pdf", "CNAME");
+  config.addPassthroughCopy("src/CNAME");
+  config.addPassthroughCopy("src/**/*.pdf");
 
   return {
     dir: {


### PR DESCRIPTION
* Wasn't sure why `addPassthroughCopy` wasn't respecting `src` as entry point
and the local build wasn't copying files when the exact `src/xxx` path wasn't specified
* https://www.11ty.dev/docs/copy/#passthrough-file-copy