### PR TITLE
Add project guideline

### DIFF
--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -27,6 +27,7 @@
           <li><a href="/code-of-conduct">Code of Conduct</a></li>
           <li><a href="/financial-reports">Financial Reports</a></li>
           <li><a href="/meeting-notes">Meeting Notes</a></li>
+          <li><a href="/project-guideline">Project Guideline</a></li>
         </ul>
       </nav>
       <p>

--- a/src/project-guideline/index.md
+++ b/src/project-guideline/index.md
@@ -1,0 +1,14 @@
+---
+layout: layouts/default.njk
+---
+
+# Project Guideline
+## What?
+This is a list of guidelines to consider following for Zinc projects. It was initially created using thoughts/ideas from our Notabli Retrospective, but ideally will become a living document, contributed to over time.
+## Recommendations
+* Agree on project priorities at the start.
+    * Examples: The goal of Project A is to become profitable. The goal of Project B is to learn about SEO.
+* Develop one workflow for the project for everyone to stick to.
+* Stick to either small steps with easier hand-offs or large steps with fewer hand-offs.
+* Name one person as the official project manager.
+* Have regular check-ins involving all stakeholders. (e.g. clients too if applicable)

--- a/src/project-guidelines/index.md
+++ b/src/project-guidelines/index.md
@@ -4,7 +4,7 @@ layout: layouts/default.njk
 
 # Project Guideline
 ## What?
-This is a list of guidelines to consider following for Zinc projects. It was initially created using thoughts/ideas from our Notabli Retrospective, but ideally will become a living document, contributed to over time.
+We've learned by doing that there are some things that make new projects flow more smoothly. This is a living document that will change over time, and was last updated on May 5th, 2020.
 ## Recommendations
 * Agree on project priorities at the start.
     * Examples: The goal of Project A is to become profitable. The goal of Project B is to learn about SEO.


### PR DESCRIPTION
Follow up on Notabli retro, @cjerozal drafted a project guideline and it seems to be great to publish publicly in markdown format for less Git savvy person to edit in the future. 
<img width="541" alt="Screen Shot 2020-05-05 at 10 54 42 AM" src="https://user-images.githubusercontent.com/8117421/81098912-e7ac9880-8ebe-11ea-93a7-510b3245fb2a.png">
