### PR TITLE
Marketing copy, Convene entering room feature

### DIFF
--- a/src/convene/index.njk
+++ b/src/convene/index.njk
@@ -105,6 +105,7 @@ summaryText: By Zinc, a Worker Cooperative
 
     <div class="mt-10">
       <ul class="md:grid md:grid-cols-2 md:col-gap-8 md:row-gap-10">
+
         <li>
           <div class="flex">
             <div class="flex-shrink-0">
@@ -122,6 +123,7 @@ summaryText: By Zinc, a Worker Cooperative
             </div>
           </div>
         </li>
+
         <li class="mt-10 md:mt-0">
           <div class="flex">
             <div class="flex-shrink-0">
@@ -141,6 +143,7 @@ summaryText: By Zinc, a Worker Cooperative
             </div>
           </div>
         </li>
+
         <li class="mt-10 md:mt-0">
           <div class="flex">
             <div class="flex-shrink-0">
@@ -158,6 +161,7 @@ summaryText: By Zinc, a Worker Cooperative
             </div>
           </div>
         </li>
+
         <li class="mt-10 md:mt-0">
           <div class="flex">
             <div class="flex-shrink-0">
@@ -177,6 +181,43 @@ summaryText: By Zinc, a Worker Cooperative
             </div>
           </div>
         </li>
+
+        <li class="mt-10 md:mt-0">
+          <div class="flex">
+            <div class="flex-shrink-0">
+              <div class="flex items-center justify-center h-12 w-12 rounded-md bg-purple-500 text-white">
+                <svg class="h-5 w-5 text-white" fill="currentColor" viewbox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                </svg>
+              </div>
+            </div>
+            <div class="ml-4">
+              <h5 class="text-lg leading-6 font-medium text-gray-900">Branded Domain</h5>
+              <p class="mt-2 text-base leading-6 text-gray-500">
+                Have your own custom domain? Use your own branded domain as your Convene workspace.
+              </p>
+            </div>
+          </div>
+        </li>
+
+        <li class="mt-10 md:mt-0">
+          <div class="flex">
+            <div class="flex-shrink-0">
+              <div class="flex items-center justify-center h-12 w-12 rounded-md bg-purple-500 text-white">
+                <svg class="h-6 w-6" stroke="currentColor" fill="none" viewbox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
+                </svg>
+              </div>
+            </div>
+            <div class="ml-4">
+              <h5 class="text-lg leading-6 font-medium text-gray-900">Sharable Room URL</h5>
+              <p class="mt-2 text-base leading-6 text-gray-500">
+                Simply share your room url to invite workspace members to join.
+              </p>
+            </div>
+          </div>
+        </li>
+
       </ul>
     </div>
 

--- a/src/convene/index.njk
+++ b/src/convene/index.njk
@@ -192,9 +192,9 @@ summaryText: By Zinc, a Worker Cooperative
               </div>
             </div>
             <div class="ml-4">
-              <h5 class="text-lg leading-6 font-medium text-gray-900">Branded Domain</h5>
+              <h5 class="text-lg leading-6 font-medium text-gray-900">Branded Domains</h5>
               <p class="mt-2 text-base leading-6 text-gray-500">
-                Have your own custom domain? Use your own branded domain as your Convene workspace.
+                It's <em>your</em> Space. Bring your own domain for a consistent brand experience.
               </p>
             </div>
           </div>
@@ -210,9 +210,9 @@ summaryText: By Zinc, a Worker Cooperative
               </div>
             </div>
             <div class="ml-4">
-              <h5 class="text-lg leading-6 font-medium text-gray-900">Sharable Room URL</h5>
+              <h5 class="text-lg leading-6 font-medium text-gray-900">Web-First</h5>
               <p class="mt-2 text-base leading-6 text-gray-500">
-                Simply share your room url to invite workspace members to join.
+                Anyone can enter a Public Space or Room through their Web address. No Downloads or Apps necessary.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Part of https://github.com/zinc-collective/convene/issues/59
Is this the marketing copy we are looking for?
Any good resource suggestion on finding svg to use or how do I make my own?
<img width="1272" alt="Screen Shot 2020-08-20 at 12 27 17 PM" src="https://user-images.githubusercontent.com/8117421/90816091-9050fd80-e2e0-11ea-89df-5a17d191d943.png">
