### PR TITLE
Explicitly call the 'build' step from the 'deploy' step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
     docker:
       - image: circleci/node:10.16.3
     steps:
+      - build
       - run:
           name: deploy-gh-pages
           command: |


### PR DESCRIPTION
This is an attempt to fix this breakage, where the attempt to deploy from the `development` branch does not seem to have access to the build artifacts from the previous build:
![Screen Shot 2020-11-13 at 10 10 10 PM](https://user-images.githubusercontent.com/6729309/99141231-205fc400-25fe-11eb-96d7-41b59490eac7.png)

(Feels a little heavy-handed, as this I think will run the install and build twice on the `development` branch. Once I get it working I can look into optimizing it, or organizing the steps better.)