### PR TITLE
Update bin/setup to use latest brew cask syntax

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,7 +3,7 @@
 # Pandoc is used to compile the source into pdf, epub, and html.
 brew install pandoc
 # BasicTex provides us with pdflatex and xelatex support
-brew cask install basictex
+brew install --cask basictex
 
 echo 'Be sure to add texlive to your path by adding `export PATH="/usr/local/texlive/2019basic/bin/x86_64-darwin:$PATH"` to your .zshrc or .bashrc'
 


### PR DESCRIPTION
This PR updates `bin/setup` so that it works with the most recent versions of Homebrew.

(Seems like these dependencies are used to convert the operating agreement to PDF after each build. I wonder if it would make more sense to have a static PDF checked into the repo and eliminate these dependencies? It's not like the operating agreement changes often.)