### PR TITLE
Add wording about Services to Products and Services page

### DIFF
--- a/src/people/index.md
+++ b/src/people/index.md
@@ -3,6 +3,8 @@ layout: default
 title: People
 ---
 
+Some members of the Zinc Collective.
+
 {% for person in people -%}
 <div class="person">
   {% if person.image -%}

--- a/src/product-and-services/index.md
+++ b/src/product-and-services/index.md
@@ -2,27 +2,30 @@
 layout: layouts/default.njk
 title: Products and Services
 ---
-## In Active Development
 
-### [Convene]
+## Products
+
+### In Active Development
+
+#### [Convene]
 
 [Convene] Convene creates human connection through safe, accessible and reliable video conferencing.
 
-### [Compensated]
+#### [Compensated]
 
 [Compensated] makes it easy for product and service developers to accept money from whichever payment processor they prefer with a low implementation or switching costs.
 
-### [We Got Your Back Today]
+#### [We Got Your Back Today]
 
 [We Got Your Back Today] is a self-or-professionally hostable support inbox for indie developers, hobbyists, and systems administrators.
 
-### [Catalog Choice]
+#### [Catalog Choice]
 
 [Catalog Choice] helps people reduce their environmental footprint by opting out of catalog mailings. We spend two to three days a month updating [Catalog Choice] for [The Story of Stuff project].
 
-## In Passive Maintenance
+### In Passive Maintenance
 
-### [MomentPark]
+#### [MomentPark]
 
 [MomentPark] is a suite of digital photography and videography apps for iOS. It currently needs contributors to help update the applications to better support iOS 13.
 
@@ -32,3 +35,16 @@ title: Products and Services
 [Catalog Choice]: https://www.catalogchoice.org
 [The Story of Stuff project]: https://storyofstuff.org
 [MomentPark]: https://www.momentpark.com
+
+## Services
+
+In addition to our original products, some [Zinc Collective members](/people) are able to build, maintain and consult for values-aligned organizations. Our current capacity is in the areas of:
+
+* research & product strategy
+* design & user experience
+* back-end engineering
+* front-end development
+* quality assurance/testing
+* senior support, consulting and mentoring
+
+ [Contact us](/contact-us) to talk more.


### PR DESCRIPTION
This PR aims to close https://github.com/zinc-collective/www.zinc.coop/issues/71 by adding the wording about "Services" in the [website content doc](https://docs.google.com/document/d/17DjiqnA5ItNQPi_Qj8NfLPgFjZba2lDZyvGq-HGjGCw/edit#heading=h.hpu7eo6q3siw) to our existing Product and Services page.

My goal here is to add some mention of Services to the site, but also to keep the number of changes to a minimum, since this is not currently something that we are prioritizing.

I've also added a line to the top of the People page trying to indicate that there are more than the two listed people at Zinc.

Here is a screenshot of what the People and Services page looks like after this change:
![localhost_8080_product-and-services_](https://user-images.githubusercontent.com/6729309/112734076-cf8f9e80-8f00-11eb-8952-677821ad8ff0.png)
