### PR TITLE
remove bkgd color and border on header links

### DIFF
--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -101,11 +101,7 @@ footer {
 }
 
 .header-item {
-  @apply px-2 py-2 text-zinc-pastel-pink bg-zinc-dark-purple border-t-2 border-l-2 border-b-2 border-zinc-pastel-pink drop-shadow-xl;
-}
-
-.header-item:last-child {
-  @apply border-r-2 border-zinc-pastel-pink;
+  @apply px-2 py-2 text-zinc-pastel-pink drop-shadow-xl;
 }
 
 .header-item:hover,


### PR DESCRIPTION
- For https://github.com/zinc-collective/www.zinc.coop/issues/103
in ref to https://github.com/zinc-collective/www.zinc.coop/issues/103#issuecomment-1594073908

# Changes
- Remove the background colors and borders on the header links
- add more spacing to the left of each icon (except the first one, the home icon), to more clearly separate each menu item
- remove the hover darker background color

![modernize header menu](https://github.com/zinc-collective/www.zinc.coop/assets/16140873/6511c9ef-baa6-4778-a127-116420700ba0)

**mobile view**
![mobile view](https://github.com/zinc-collective/www.zinc.coop/assets/16140873/10fbb055-c7ad-47cc-8716-1a02e12a9940)
