### PR TITLE
make hover link color WCAG compliant

### DIFF
--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -26,7 +26,7 @@ a {
 }
 
 a:hover {
-  @apply text-zinc-pastel-red;
+  @apply text-zinc-pastel-purple;
 }
 
 /* Visited states in same color as not-visited states. */
@@ -35,7 +35,7 @@ a:visited {
 }
 
 a:visited:hover {
-  @apply text-zinc-pastel-red;
+  @apply text-zinc-pastel-purple;
 }
 
 ul {
@@ -101,12 +101,12 @@ footer {
 }
 
 .header-item {
-  @apply px-2 py-2 text-zinc-pastel-pink drop-shadow-xl;
+  @apply px-2 py-2 ml-2 text-zinc-pastel-pink drop-shadow-xl;
 }
 
 .header-item:hover,
 .header-item:active {
-  @apply bg-zinc-dark-purple text-zinc-pastel-red;
+  @apply text-zinc-pastel-purple;
 }
 
 .dropdown-container {

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -26,7 +26,7 @@ a {
 }
 
 a:hover {
-  @apply text-zinc-hover-color;
+  @apply text-zinc-pastel-blue;
 }
 
 /* Visited states in same color as not-visited states. */
@@ -35,7 +35,7 @@ a:visited {
 }
 
 a:visited:hover {
-  @apply text-zinc-hover-color;
+  @apply text-zinc-pastel-blue;
 }
 
 ul {
@@ -110,7 +110,7 @@ footer {
 
 .header-item:hover,
 .header-item:active {
-  @apply bg-zinc-dark-purple text-zinc-hover-color;
+  @apply bg-zinc-dark-purple text-zinc-pastel-blue;
 }
 
 .dropdown-container {

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -26,7 +26,7 @@ a {
 }
 
 a:hover {
-  @apply text-zinc-pastel-blue;
+  @apply text-zinc-pastel-red;
 }
 
 /* Visited states in same color as not-visited states. */
@@ -35,7 +35,7 @@ a:visited {
 }
 
 a:visited:hover {
-  @apply text-zinc-pastel-blue;
+  @apply text-zinc-pastel-red;
 }
 
 ul {
@@ -110,7 +110,7 @@ footer {
 
 .header-item:hover,
 .header-item:active {
-  @apply bg-zinc-dark-purple text-zinc-pastel-blue;
+  @apply bg-zinc-dark-purple text-zinc-pastel-red;
 }
 
 .dropdown-container {

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -26,7 +26,7 @@ a {
 }
 
 a:hover {
-  @apply text-zinc-darker-pastel-pink;
+  @apply text-zinc-hover-color;
 }
 
 /* Visited states in same color as not-visited states. */
@@ -35,7 +35,7 @@ a:visited {
 }
 
 a:visited:hover {
-  @apply text-zinc-darker-pastel-pink;
+  @apply text-zinc-hover-color;
 }
 
 ul {
@@ -110,7 +110,7 @@ footer {
 
 .header-item:hover,
 .header-item:active {
-  @apply bg-zinc-dark-purple text-zinc-darker-pastel-pink;
+  @apply bg-zinc-dark-purple text-zinc-hover-color;
 }
 
 .dropdown-container {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,9 +10,8 @@ module.exports = {
       colors: {
         'zinc-purple': '#332658',
         'zinc-dark-purple': '#1F1735',
-        'zinc-hot-pink': '#F43EF3',
         'zinc-pastel-pink': '#FE9BFF',
-        'zinc-darker-pastel-pink': '#C966CA',
+        'zinc-pastel-blue': '#9BE4FF',
       }
     }
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,10 @@ module.exports = {
         'zinc-dark-purple': '#1F1735',
         'zinc-pastel-pink': '#FE9BFF',
         'zinc-pastel-blue': '#9BE4FF',
+        'zinc-pastel-yellow': '#FFE99B',
+        'zinc-pastel-green': '#9BFFA3',
+        'zinc-pastel-purple': '#A79BFF',
+        'zinc-pastel-red': '#FF9B9B',
       }
     }
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,11 +11,7 @@ module.exports = {
         'zinc-purple': '#332658',
         'zinc-dark-purple': '#1F1735',
         'zinc-pastel-pink': '#FE9BFF',
-        'zinc-pastel-blue': '#9BE4FF',
-        'zinc-pastel-yellow': '#FFE99B',
-        'zinc-pastel-green': '#9BFFA3',
         'zinc-pastel-purple': '#A79BFF',
-        'zinc-pastel-red': '#FF9B9B',
       }
     }
   }


### PR DESCRIPTION
- for https://github.com/zinc-collective/www.zinc.coop/issues/103
ref to https://github.com/zinc-collective/www.zinc.coop/pull/116#pullrequestreview-1482523608 and [discussion](https://github.com/zinc-collective/www.zinc.coop/pull/116#issuecomment-1594055940)

# Changes
- add [changes](https://github.com/zinc-collective/www.zinc.coop/issues/103#issuecomment-1595352239) that failed to be committed in https://github.com/zinc-collective/www.zinc.coop/pull/117
  - remove hover darker purple background color in header menu items
  - add a bit more spacing to the left of each icon, to more clearly separate each menu item

![changes](https://github.com/zinc-collective/www.zinc.coop/assets/16140873/335734ba-ebb9-4176-af77-c7f8bbfacb97)

- change :hover color to WCAG compliant purple
<img width="1505" alt="Screenshot 2023-06-18 at 7 26 17 AM" src="https://github.com/zinc-collective/www.zinc.coop/assets/16140873/5bfff9cf-0f12-4158-b147-82845a9db8a0">
<img width="1540" alt="Screenshot 2023-06-18 at 7 26 27 AM" src="https://github.com/zinc-collective/www.zinc.coop/assets/16140873/b2b81e98-d0b8-4005-bfd9-64d7dcc3a028">
