### PR TITLE
Address accessible link and duplicate H1 issues.

### DIFF
--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -10,7 +10,6 @@
   <body>
     {% include "partials/header.njk" %}
     <main>
-      <h1>{{ title }}</h1>
       {{ content | safe }}
     </main>
     {% include "partials/footer.njk" %}

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -10,6 +10,7 @@
   <body>
     {% include "partials/header.njk" %}
     <main>
+      <h1>{{ title }}</h1>
       {{ content | safe }}
     </main>
     {% include "partials/footer.njk" %}

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -1,4 +1,4 @@
-<header class="header-container" role="navigation">
+<header class="header-container" aria-label="Main navigation">
 
   {# ----- Home Menu Item ----- #}
   <a class="header-item" href="/">

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -1,8 +1,8 @@
-<header class="header-container" role="navigation" aria-label="main navigation">
+<header class="header-container" role="navigation">
 
   {# ----- Home Menu Item ----- #}
   <a class="header-item" href="/">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+    <svg aria-label="Homepage" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
     </svg>
   </a>
@@ -30,7 +30,7 @@
     </svg>
     Join us
   </a>
-  
+
   {# ----- Updates Menu Item ----- #}
   <a class="header-item" href="/updates">
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mr-2 inline-block">

--- a/src/a11y.md
+++ b/src/a11y.md
@@ -1,0 +1,14 @@
+---
+layout: layouts/default.njk
+permalink: a11y.html
+title: Accessibility Report
+---
+<p>There is a title missing from the following sections:</p>
+
+<ul>
+  {% for page in collections.all %}
+    {% if not page.data.title %}
+      <li>Missing title: {{ page.url }}</li>
+    {% endif %}
+  {% endfor %}
+</ul>

--- a/src/compensated.md
+++ b/src/compensated.md
@@ -1,8 +1,7 @@
 ---
 layout: layouts/default.njk
+title: Compensated
 ---
-
-# Compensated
 
 Build products. Get paid.
 

--- a/src/index.md
+++ b/src/index.md
@@ -3,7 +3,7 @@ layout: layouts/default.njk
 ---
 # The Zinc Collective
 
-🤗 We are an open-source volunteer coding group of diverse individuals. 
+🤗 We are an open-source volunteer coding group of diverse individuals.
 
 🗓️ We meet weekly to work on coding projects.
 
@@ -13,4 +13,4 @@ We strive for a post-scarcity society by:
 *   Redistributing that wealth in a way that rectifies socioeconomic power imbalances.
 *   Taking responsibility for and reducing the social and ecological costs of our digital products and services.
 
-  <p>💌 Email us at <a href="mailto:hello@zinc.coop">hello@zinc.coop</a>. We love mail!</p>
+<p>💌 Email us at <a class="underline" href="mailto:hello@zinc.coop">hello@zinc.coop</a>. We love mail!</p>

--- a/src/index.md
+++ b/src/index.md
@@ -1,8 +1,7 @@
 ---
 layout: layouts/default.njk
+title: The Zinc Collective
 ---
-# The Zinc Collective
-
 🤗 We are an open-source volunteer coding group of diverse individuals.
 
 🗓️ We meet weekly to work on coding projects.

--- a/src/product-and-services/index.md
+++ b/src/product-and-services/index.md
@@ -26,12 +26,11 @@ A suite of digital photography and videography apps for iOS. It currently needs 
 
 ## Services
 
-In addition to our original products, some [Zinc Collective members](/about-us) are able to build, maintain and consult for values-aligned organizations. 
+In addition to our original products, some [Zinc Collective members](/about-us) are able to build, maintain and consult for values-aligned organizations.
 
 Our current capacity is in the areas of:
 
 * Hosting a Space on [Convene](https://convene.zinc.coop/)
 * Hosting a [Convene](https://convene.zinc.coop/) Neighborhood
 
- <p>💌 Email us at <a href="mailto:hello@zinc.coop">hello@zinc.coop</a> to talk more.</p>
-  
+<p>💌 Email us at <a class="underline" href="mailto:hello@zinc.coop">hello@zinc.coop</a> to talk more.</p>

--- a/src/updates/index.md
+++ b/src/updates/index.md
@@ -7,7 +7,7 @@ News and Updates are posted Quarterly-ish on our <a href="https://opencollective
 
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 float-left mr-2 mt-8">
   <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
-</svg> 
+</svg>
 
 ## Financial Overview
 


### PR DESCRIPTION
Here are some WCAG flags that I noticed. Details are courtesy of the [ARC](https://www.tpgi.com/arc-platform/arc-toolkit/), [WAVE](https://wave.webaim.org/extension/) [Axe](https://www.deque.com/axe/devtools/chrome-browser-extension/), and [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) plug-ins on the Chrome and Firefox browsers.
## Short summary
- Use aria-label for SVG so that Homepage is narrated for screen reader users
- The content variable seems to include an H1 tag. Remove other H1, which also appears on the homepage
- Use underline CSS so that link is distinguishable without relying on color alone
- Screen readers are reading out both "navigation" (set by role) and "main navigation" (set by aria-label). We should remove one so it's not duplicative. 

## Long summary

[3.1.2 - Name, Role, Purpose](https://www.w3.org/TR/WCAG22/#name-role-value)

<img width="2516" alt="ARC shows aria-label name-role-purpose failure" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/32c94e2a-b3d1-4a22-9a52-909e0cfde97a">

The SVG icon visually displays a home icon. However, it does not communicate its purpose as a homepage to screen reader users. Images should generally have alt text or an aria-label to describe its meaning. For screen readers, it narrates as "www.zinc.coop". To make context clearer, since it's a homepage, we can use "Zinc homepage" or "homepage" as the text content. 

The following is from the NVDA screen reader. In addition to narrating web content in speech mode, NVDA also includes a document review, which is shown here. Notice that the log mentions the duplicate navigation/main navigation and that the home icon does not match the convention of the other categories (Product and Services, About Us, Join Us, Updates).

<img width="386" alt="NVDA shows homepage has no description" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/34012251-f5b6-4945-809c-8c119476c249">

[2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG22/#link-purpose-in-context)

Technically `mailto:`creates a link so we'd like to include something text-based like an underline so color isn't the sole determining factor for a link. This will help low-vision and color-blind users.

There were two H1s on the default page. I tried tinkering with an "if title" statement but it didn't seem to work. The only action that removed the duplicate H1 was removing the H1 tag within main. I think this means the other H1 must be wrapped in the content variable and it seems like the content variable controls rendering of most of the body. Can someone confirm this is the correct action to take?

<img width="298" alt="Duplicate H1s" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/b28169b2-8387-4e75-a4cc-fe220934c3b0">

## Before

WAVE results:
<img width="1079" alt="2 WAVE errors" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/5103f467-582e-4da1-b4b6-6116549bec28">
Axe results:
<img width="1148" alt="2 Axe errors" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/1ed5f41b-ad6f-4490-a380-4c5e38bf5432">
Lighthouse results:
<img width="1269" alt="89% Lighthouse score" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/a9bab350-ff81-4d39-a519-811ad6e55114">

## After
WAVE results:
<img width="729" alt="0 WAVE errors" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/66d0a724-2715-466d-94d2-b3446eb00095">

Axe results:
<img width="935" alt="0 Axe errors" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/4a2b1075-efc4-4ee7-91b3-db0dc98102ab">

Lighthouse results:
<img width="883" alt="100% Lighthouse score" src="https://github.com/zinc-collective/www.zinc.coop/assets/12864533/dbe80b95-dd6c-441c-9dc5-08f64865c83b">
