### PR TITLE
Pins node package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "CC-BY-SA-4.0",
       "dependencies": {
-        "@11ty/eleventy": "^2.0.1",
-        "@tailwindcss/aspect-ratio": "^0.4.0",
-        "@tailwindcss/forms": "^0.5.0",
-        "@tailwindcss/typography": "^0.5.2",
-        "autoprefixer": "^10.4.4",
-        "postcss": "^8.4.31",
-        "tailwindcss": "^3.0.24"
+        "@11ty/eleventy": "2.0.1",
+        "@tailwindcss/aspect-ratio": "0.4.0",
+        "@tailwindcss/forms": "0.5.0",
+        "@tailwindcss/typography": "0.5.2",
+        "autoprefixer": "10.4.4",
+        "postcss": "8.4.31",
+        "tailwindcss": "3.0.24"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Public website for zinc.coop",
   "main": "index.js",
   "dependencies": {
-    "@11ty/eleventy": "^2.0.1",
-    "@tailwindcss/aspect-ratio": "^0.4.0",
-    "@tailwindcss/forms": "^0.5.0",
-    "@tailwindcss/typography": "^0.5.2",
-    "autoprefixer": "^10.4.4",
-    "postcss": "^8.4.31",
-    "tailwindcss": "^3.0.24"
+    "@11ty/eleventy": "2.0.1",
+    "@tailwindcss/aspect-ratio": "0.4.0",
+    "@tailwindcss/forms": "0.5.0",
+    "@tailwindcss/typography": "0.5.2",
+    "autoprefixer": "10.4.4",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.0.24"
   },
   "scripts": {
     "after-build": "pandoc dist/operating-agreement/index.html -o dist/operating-agreement/index.pdf",


### PR DESCRIPTION
This is generally advised to avoid any unexpected bumps during local or CI builds that might cause unintended inconsistencies or problems.  